### PR TITLE
#366  qulice-maven-plugin:0.12 removed from pom.xml, parent updated to 0.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>parent</artifactId>
-        <version>0.29</version>
+        <version>0.32</version>
     </parent>
     <groupId>com.qulice</groupId>
     <artifactId>qulice</artifactId>
@@ -130,16 +130,5 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <!--
-        @todo #308 Remove this declaration when parent pom would depends
-         on qulice-maven-plugin:0.12
-         -->
-        <plugins>
-            <plugin>
-                <groupId>com.qulice</groupId>
-                <artifactId>qulice-maven-plugin</artifactId>
-                <version>0.12</version>
-            </plugin>
-        </plugins>
     </build>
 </project>

--- a/qulice-maven-plugin/src/it/codenarc-violations/module/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/codenarc-violations/module/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2011-2014, Qulice.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met: 1) Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer. 2) Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution. 3) Neither the name of the Qulice.com nor
+the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/qulice-maven-plugin/src/it/codenarc-violations/module/pom.xml
+++ b/qulice-maven-plugin/src/it/codenarc-violations/module/pom.xml
@@ -70,6 +70,7 @@
                 <executions>
                     <execution>
                         <configuration>
+	                    <license>file:${basedir}/LICENSE.txt</license>
                             <excludes>
                                 <exclude>codenarc:**/test/*.groovy</exclude>
                             </excludes>

--- a/qulice-maven-plugin/src/it/js-violations/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/js-violations/LICENSE.txt
@@ -1,0 +1,28 @@
+Copyright (c) 2011-2014, Qulice.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met: 1) Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer. 2) Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution. 3) Neither the name of the Qulice.com nor
+the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/qulice-maven-plugin/src/it/js-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/js-violations/pom.xml
@@ -49,6 +49,9 @@
                 <groupId>com.qulice</groupId>
                 <artifactId>qulice-maven-plugin</artifactId>
                 <version>@project.version@</version>
+                <configuration>
+                    <license>file:${basedir}/LICENSE.txt</license>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Issue #366 resolved.
qulice-maven-plugin:0.12 removed from pom.xml
parent updated to 0.32