### PR TITLE
#139 Verify that IndentationCheck bug is not present

### DIFF
--- a/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/IndentationChecks.java
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/src/main/java/com/qulice/plugin/violations/IndentationChecks.java
@@ -1,0 +1,24 @@
+/**
+ * Test file.
+ */
+package com.qulice.plugin.violations;
+
+/**
+ * Indentation checks.
+ */
+public final class IndentationChecks {
+
+    /**
+     * This should not produce any violations.
+     */
+    public void triggersNoViolation() {
+        new String()
+            .substring(
+                0, 2
+            )
+            .substring(
+                0, 1
+            );
+    }
+
+}

--- a/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
@@ -51,4 +51,6 @@ assert log.text.contains('Violations.java[40]: ArrayList should be initialized w
 assert log.text.findAll('Pdd.java.*: @todo tag has wrong format').empty
 assert !log.text.contains('Got an exception - java.lang.NullPointerException')
 //assert !log.text.contains('SomeTest.java[5]: This method must be static, because it does not refer to "this"')
-assert !log.text.contains('IndentationChecks.java[19]: method call rparen at indentation level 12 not at correct indentation, 8 (IndentationCheck)')
+assert !log.text.contains(
+    'IndentationChecks.java[19]: method call rparen at indentation level 12 not at correct indentation, 8 (IndentationCheck)'
+)

--- a/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
@@ -51,3 +51,4 @@ assert log.text.contains('Violations.java[40]: ArrayList should be initialized w
 assert log.text.findAll('Pdd.java.*: @todo tag has wrong format').empty
 assert !log.text.contains('Got an exception - java.lang.NullPointerException')
 //assert !log.text.contains('SomeTest.java[5]: This method must be static, because it does not refer to "this"')
+assert !log.text.contains('IndentationChecks.java[19]: method call rparen at indentation level 12 not at correct indentation, 8 (IndentationCheck)')

--- a/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
@@ -51,6 +51,4 @@ assert log.text.contains('Violations.java[40]: ArrayList should be initialized w
 assert log.text.findAll('Pdd.java.*: @todo tag has wrong format').empty
 assert !log.text.contains('Got an exception - java.lang.NullPointerException')
 //assert !log.text.contains('SomeTest.java[5]: This method must be static, because it does not refer to "this"')
-assert !log.text.contains(
-    'IndentationChecks.java[19]: method call rparen at indentation level 12 not at correct indentation, 8 (IndentationCheck)'
-)
+assert !log.text.contains('IndentationChecks.java[19]: method call rparen at indentation level 12')


### PR DESCRIPTION
The `IndentationCheck` bug described was fixed in Checkstyle 5.9. See http://checkstyle.sourceforge.net/releasenotes.html and https://github.com/checkstyle/checkstyle/issues/294. I added a test case to show that it is working now.