### PR TITLE
Fix PomXpathValidator javadoc

### DIFF
--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -39,11 +39,14 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 
 /**
- * Check pom.xml with XPath validation queries.
+ * <p>Check pom.xml with XPath validation queries.</p>
  *
- * Restrictions:
- * 1. Each xpath component should contains namespace prefix pom:
- * 2. Each xpath query should end with /text()
+ * <p>Restrictions:</p>
+ *
+ * <ol>
+ * <li>Each xpath component should contains namespace prefix pom:</li>
+ * <li>Each xpath query should end with /text()</li>
+ * </ol>
  *
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$


### PR DESCRIPTION
**Before**

> Check pom.xml with XPath validation queries. Restrictions: 1. Each xpath component should contains namespace prefix pom: 2. Each xpath query should end with /text()

**After**

> Check pom.xml with XPath validation queries.
> 
> Restrictions:
> 
> 1. Each xpath component should contains namespace prefix pom:
> 2. Each xpath query should end with /text()