### PR TITLE
#471 tuned check to not report a problem when constructor params equal  fields

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -211,7 +211,9 @@
         <module name="EqualsAvoidNull"/>
         <module name="EqualsHashCode"/>
         <module name="FinalLocalVariable"/>
-        <module name="HiddenField"/>
+        <module name="HiddenField">
+            <property name="ignoreConstructorParameter" value="true"/>
+        </module>
         <module name="IllegalInstantiation"/>
         <module name="IllegalToken">
             <property name="tokens" value="POST_INC, POST_DEC"/>

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ConstructorParams.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ConstructorParams.java
@@ -1,0 +1,34 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+public final class ConstructorParams {
+    /**
+     * Some number.
+     */
+    private final int number;
+
+    /**
+     * Constructor.
+     * @param number Some nice number.
+     */
+    public ConstructorParams(final int number) {
+        this.number = number;
+    }
+
+    /**
+     * Add an external number to internal one.
+     * @param number Number to add.
+     * @return Sum of numbers.
+     */
+    public int addNumber(final int number) {
+        return this.number + number;
+    }
+}
+


### PR DESCRIPTION
#471 
* added test to check the new condition for constructor params (allow same name as fields) and for method params (no change)
* fixed by adding `HiddenField` parameter