### PR TITLE
#515 Disallow methods with multiple return statements

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -236,7 +236,9 @@
         <module name="IllegalCatch"/>
         <module name="IllegalThrows"/>
         <module name="PackageDeclaration"/>
-        <module name="ReturnCount" />
+        <module name="ReturnCount">
+            <property name="max" value="1"/>
+        </module>
         <module name="IllegalType"/>
         <module name="DeclarationOrder"/>
         <module name="ParameterAssignment"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -221,6 +221,19 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator reports an error when any method contains more
+     * than one return statement.
+     * @throws Exception when error.
+     */
+    @Test
+    public void reportsErrorOnMoreThanOneReturnStatement() throws Exception {
+        this.validateCheckstyle(
+            "ReturnCount.java", false,
+            Matchers.containsString("Return count is 2 (max allowed is 1)")
+        );
+    }
+
+    /**
      * CheckstyleValidator can accept default methods with final modifiers.
      * @throws Exception In case of error
      */

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ReturnCount.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ReturnCount.java
@@ -1,0 +1,22 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+public final class ReturnCount {
+    /**
+     * Method with two {@code return} statements.
+     * @param number Some nice number.
+     */
+    public int methodWithTwoReturns(final int number) {
+        if (number == 0) {
+            return 0;
+        }
+        return 1;
+    }
+}


### PR DESCRIPTION
* ReturnCount check is configured to enforce at most one return statement in each method
* Integration test is added

Implementation for #515.