### PR TITLE
#519 Fix integration test for non-English locale

### DIFF
--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -103,6 +103,12 @@
                     <path>${project.artifactId}</path>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Duser.language=en -Duser.country=US</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
Additional fix for #519:
* There is integration test to verify completion of issue #519 introduced in #529
* `ChecksTest` was randomly failing when it was run on JVM with non-English locale, this commit fixes it
* There's no other possibility to verify whether tests work correctly except running another build, but this idea was rejected in https://github.com/teamed/qulice/pull/529#discussion_r48008636
* All difficulty with locale here is connected to the fact, that Checkstyle statically caches all error messages and uses localized ones by default
  * Any test can populate static cache with localized messages and then next test has dirty state and messages in different message than expected
