### PR TITLE
#527 Enable strict condition in Checkstyle Indentation check

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -296,7 +296,9 @@
         <module name="FinalParameters">
             <property name="tokens" value="CTOR_DEF,METHOD_DEF,FOR_EACH_CLAUSE,LITERAL_CATCH"/>
         </module>
-        <module name="Indentation"/>
+        <module name="Indentation">
+            <property name="forceStrictCondition" value="true"/>
+        </module>
         <module name="CommentsIndentation"/>
         <module name="TrailingComment"/>
         <module name="OuterTypeFilename"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -221,6 +221,21 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator reports an error when indentation is not strict.
+     * @throws Exception when error.
+     */
+    @Test
+    public void reportsErrorWhenIndentationIsNotStrict() throws Exception {
+        this.validateCheckstyle(
+            "StrictIndentation.java",
+            false,
+            Matchers.containsString(
+                "incorrect indentation level 14, expected level should be 12"
+            )
+        );
+    }
+
+    /**
      * CheckstyleValidator reports an error when any method contains more
      * than one return statement.
      * @throws Exception when error.

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/StrictIndentation.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/StrictIndentation.java
@@ -1,0 +1,20 @@
+/**
+ * Hello.
+ */
+package foo.bar;
+
+/**
+ * Simple.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+public class StrictIndentation {
+    public StrictIndentation() {
+        final String first = String.format(
+              "incorrect"
+        );
+        final String correct = String.format(
+            "correct"
+        );
+    }
+}


### PR DESCRIPTION
For #527:
* change config for Indentation check to enforce strict indentation (not more spaces than needed)
* unit test added