### PR TITLE
Cheklist bug: expression list token (ELIST) reports invalid line number when used as method param

### DIFF
--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
@@ -81,23 +81,22 @@ public final class DetailASTTest {
      * @param ast Tree to search
      * @param type Token type
      * @return Token node if found
-     * @checkstyle ReturnCountCheck (2 lines)
      */
-    @SuppressWarnings("PMD.OnlyOneReturn")
     private static Optional<DetailAST> findToken(final DetailAST ast,
         final int type) {
+        Optional<DetailAST> token = Optional.absent();
         DetailAST child = ast.getFirstChild();
         while (child != null) {
-            final DetailAST token = child.findFirstToken(type);
-            if (token != null) {
-                return Optional.of(token);
+            token = Optional.fromNullable(child.findFirstToken(type));
+            if (token.isPresent()) {
+                break;
             }
-            final Optional<DetailAST> deep = findToken(child, type);
-            if (deep.isPresent()) {
-                return deep;
+            token = findToken(child, type);
+            if (token.isPresent()) {
+                break;
             }
             child = child.getNextSibling();
         }
-        return Optional.absent();
+        return token;
     }
 }

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
@@ -53,8 +53,9 @@ public final class DetailASTTest {
     /**
      * ELIST token should return valid line number.
      * @throws Exception If something goes wrong
-     * @todo #541:30min/DEV Test BracketsStructureCheck with fixed checkstyle
-     *  version.
+     * @todo #541:30min/DEV This test does not pass at the moment because of
+     *  the bug in checkstyle lib. We should test again with fixed version and
+     *  verify BracketsStructureCheck behaviour.
      */
     @Ignore
     @Test

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2011-2015, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle;
+
+import com.google.common.base.Optional;
+import com.puppycrawl.tools.checkstyle.TreeWalker;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.FileContents;
+import com.puppycrawl.tools.checkstyle.api.FileText;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test case for {@link DetailAST}.
+ * @author I. Sokolov (happy.neko@gmail.com)
+ * @version $Id$
+ */
+public final class DetailASTTest {
+
+    /**
+     * ELIST token should return valid line number.
+     * @throws Exception If something goes wrong
+     * @todo #541:30min/DEV Test BracketsStructureCheck with fixed checkstyle
+     *  version.
+     */
+    @Ignore
+    @Test
+    public void expressionListTokeHasValidLineNumber() throws Exception {
+        final String path = "/com/qulice/checkstyle/ExpressionList.java";
+        final FileContents contents =
+            new FileContents(
+                new FileText(
+                    new File(this.getClass().getResource(path).getFile()),
+                    StandardCharsets.UTF_8.name()
+                )
+            );
+        final DetailAST ast = TreeWalker.parse(contents);
+        final DetailAST token = findToken(ast, TokenTypes.ELIST).get();
+        MatcherAssert.assertThat(
+            token.getLineNo(),
+            Matchers.equalTo(
+                token.getPreviousSibling().getLineNo()
+            )
+        );
+    }
+
+    /**
+     * Recursive token search.
+     * @param ast Tree to search
+     * @param type Token type
+     * @return Token node if found
+     * @checkstyle ReturnCountCheck (2 lines)
+     */
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    private static Optional<DetailAST> findToken(final DetailAST ast,
+        final int type) {
+        DetailAST child = ast.getFirstChild();
+        while (child != null) {
+            final DetailAST token = child.findFirstToken(type);
+            if (token != null) {
+                return Optional.of(token);
+            }
+            final Optional<DetailAST> deep = findToken(child, type);
+            if (deep.isPresent()) {
+                return deep;
+            }
+            child = child.getNextSibling();
+        }
+        return Optional.absent();
+    }
+}

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/DetailASTTest.java
@@ -46,6 +46,7 @@ import org.junit.Test;
  * Test case for {@link DetailAST}.
  * @author I. Sokolov (happy.neko@gmail.com)
  * @version $Id$
+ * @since 0.14.2
  */
 public final class DetailASTTest {
 

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExpressionList.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExpressionList.java
@@ -1,0 +1,11 @@
+/**
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a resource in DetailASTTest.
+ */
+public final class ExpressionList {
+    public final void test() {
+        throw new IllegalStateException("Wrapped"
+            + " message " + ex.getMessage(), null
+        );
+    }
+}


### PR DESCRIPTION
Unit test to confirm ticket #503 caused by checkstyle bug.