### PR TITLE
#461 Prohibit a semicolon in the end of try-with-resourses head

### DIFF
--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -267,6 +267,19 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * Fail validation with extra semicolon in the end
+     * of try-with-resources head.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void testExtraSemicolonInTryWithResources() throws Exception {
+        this.validateCheckstyle(
+            "ExtraSemicolon.java", false,
+            Matchers.containsString("Only one statement per line allowed.")
+        );
+    }
+
+    /**
      * Convert file name to URL.
      * @param file The file
      * @return The URL

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
@@ -1,0 +1,28 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+public final class ExtraSemicolon {
+    /**
+     * Method with extra semicolon in the end
+     * of try-with-resources head.
+     */
+    public void view() {
+        try (
+            final Closeable door = new Door();
+            final Closeable window = new Window();
+        ) {
+            int data = input.read();
+            while (data != -1) {
+                System.out.print((char) data);
+                data = input.read();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a unit test to confirm that the behaviour already exists since upgrade to Checkstyle 6.12.1