### PR TITLE
#461 Prohibit a semicolon in the end of try-with-resourses head

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2011-2015, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.Check;
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+
+/**
+ * Checks that try-with-resources does not end with a semicolon.
+ *
+ * @author Hamdi Douss (douss.hamdi@gmail.com)
+ * @version $Id$
+ */
+public final class FinalSemicolonInTryWithResourcesCheck extends Check {
+
+    @Override
+    public int[] getDefaultTokens() {
+        return new int[]{
+            TokenTypes.RESOURCE_SPECIFICATION,
+        };
+    }
+
+    /**
+     * Implementation relies on existence of semicolon inside of
+     * RESOURCE_SPECIFICATION token as interpreted by Checkstyle.
+     * @param ast RESOURCE_SPECIFICATION token
+     */
+    @Override
+    public void visitToken(final DetailAST ast) {
+        final int semicolons = ast.getChildCount(TokenTypes.SEMI);
+        if (semicolons == 1) {
+            this.log(
+                ast.getLineNo(),
+                "Extra semicolon in the end of try-with-resources head."
+            );
+        }
+    }
+}

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
@@ -56,7 +56,7 @@ public final class FinalSemicolonInTryWithResourcesCheck extends Check {
     @Override
     public void visitToken(final DetailAST ast) {
         final int semicolons = ast.getChildCount(TokenTypes.SEMI);
-        if (semicolons == 1) {
+        if (semicolons > 0) {
             this.log(
                 ast.getLineNo(),
                 "Extra semicolon in the end of try-with-resources head."

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -380,6 +380,7 @@
         </module>
         -->
         <module name="com.qulice.checkstyle.ProtectedMethodInFinalClassCheck"/>
+        <module name="com.qulice.checkstyle.FinalSemicolonInTryWithResourcesCheck"/>
     </module>
 
     <!--

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -267,6 +267,19 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * Fail validation with extra semicolon in the end
+     * of try-with-resources head.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void testExtraSemicolonInTryWithResources() throws Exception {
+        this.validateCheckstyle(
+            "ExtraSemicolon.java", false,
+            Matchers.containsString("Only one statement per line allowed.")
+        );
+    }
+
+    /**
      * Convert file name to URL.
      * @param file The file
      * @return The URL

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -282,6 +282,19 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * Accepts try-with-resources without extra semicolon
+     * at the end of the head.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void acceptsTryWithResourcesWithoutSemicolon() throws Exception {
+        this.validateCheckstyle(
+            "ValidSemicolon.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
      * Convert file name to URL.
      * @param file The file
      * @return The URL

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -275,7 +275,9 @@ public final class CheckstyleValidatorTest {
     public void testExtraSemicolonInTryWithResources() throws Exception {
         this.validateCheckstyle(
             "ExtraSemicolon.java", false,
-            Matchers.containsString("Only one statement per line allowed.")
+            Matchers.containsString(
+                "Extra semicolon in the end of try-with-resources head."
+            )
         );
     }
 

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
@@ -17,6 +17,7 @@ public final class ExtraSemicolon {
         try (
             final Closeable door = new Door();
             final Closeable window = new Window();
+            final Closeable win = new Window();
         ) {
             int data = input.read();
             while (data != -1) {

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ExtraSemicolon.java
@@ -1,0 +1,28 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+public final class ExtraSemicolon {
+    /**
+     * Method with extra semicolon in the end
+     * of try-with-resources head.
+     */
+    public void view() {
+        try (
+            final Closeable door = new Door();
+            final Closeable window = new Window();
+        ) {
+            int data = input.read();
+            while (data != -1) {
+                System.out.print((char) data);
+                data = input.read();
+            }
+        }
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidSemicolon.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidSemicolon.java
@@ -1,0 +1,29 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+public final class ValidSemicolon {
+    /**
+     * Method without extra semicolon in the end
+     * of try-with-resources head.
+     */
+    public void view() {
+        try (
+            final Closeable door = new Door();
+            final Closeable window = new Window();
+            final Closeable win = new Window()
+        ) {
+            int data = input.read();
+            while (data != -1) {
+                System.out.print((char) data);
+                data = input.read();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolving #461 Prohibit a semicolon in the end of try-with-resourses head.
Checkstyle consider final (optional) semicolon as belonging to the RESOURCE_SPECIFICATION token, so it is enough to test if RESOURCE_SPECIFICATION contains a semicolon.