### PR TITLE
Upgrade dependencies #553

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>parent</artifactId>
-        <version>0.33</version>
+        <version>0.40</version>
     </parent>
     <groupId>com.qulice</groupId>
     <artifactId>qulice</artifactId>

--- a/qulice-ant/pom.xml
+++ b/qulice-ant/pom.xml
@@ -114,15 +114,6 @@
 
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <!--
-                Latest version of the plugin (1.8) is based on Groovy 2.0.1,
-                which is based on ASM 4.0, while CodeNarc and FindBugs are still using ASM 3.x.
-                This version mismatch leads to an exception in runtime,
-                explained in http://stackoverflow.com/questions/11738732/
-                That's why we downgrade the version here to 1.6, which is
-                based on Groovy 1.8.6, which is using ASM 3.2.
-                -->
-                <version>1.6</version>
                 <configuration combine.children="append">
                     <mergeUserSettings>false</mergeUserSettings>
                     <pomIncludes>

--- a/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
@@ -47,7 +47,7 @@ public class AntEnvironmentTest {
      */
     @Test
     @Ignore
-    @SuppressWarnings("PMD.UncommentedEmptyMethod")
+    @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
     public void buildsClassloader() throws Exception {
     }
 
@@ -57,7 +57,7 @@ public class AntEnvironmentTest {
      */
     @Test
     @Ignore
-    @SuppressWarnings("PMD.UncommentedEmptyMethod")
+    @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
     public void returnsFiles() throws Exception {
     }
 
@@ -67,7 +67,7 @@ public class AntEnvironmentTest {
      */
     @Test
     @Ignore
-    @SuppressWarnings("PMD.UncommentedEmptyMethod")
+    @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
     public void excludesFiles() throws Exception {
     }
 }

--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.12.1</version>
+            <version>6.14</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.abego.treelayout</groupId>

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -54,14 +54,14 @@ final class CheckstyleListener implements AuditListener {
     /**
      * Collection of events collected.
      */
-    private final transient List<AuditEvent> all =
-        new LinkedList<AuditEvent>();
+    private final transient List<AuditEvent> all;
 
     /**
      * Public ctor.
      * @param environ The environment
      */
     CheckstyleListener(final Environment environ) {
+        this.all = new LinkedList<AuditEvent>();
         this.env = environ;
     }
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
@@ -112,7 +112,7 @@ public final class StringLiteralsConcatenationCheck extends Check {
      * @return True if of type, false otherwise.
      * @see TokenTypes
      */
-    private boolean isOfType(final DetailAST ast, final int[] types) {
+    private boolean isOfType(final DetailAST ast, final int... types) {
         boolean yes = false;
         for (final int type : types) {
             if (ast.getType() == type) {

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -86,7 +86,7 @@ public final class LicenseRule implements TestRule {
      * @param lns The lines to use
      * @return This object
      */
-    public LicenseRule withLines(final String[] lns) {
+    public LicenseRule withLines(final String... lns) {
         this.lines = new String[lns.length];
         System.arraycopy(lns, 0, this.lines, 0, lns.length);
         return this;

--- a/qulice-findbugs/pom.xml
+++ b/qulice-findbugs/pom.xml
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>com.jcabi.incubator</groupId>
             <artifactId>xembly</artifactId>
-            <version>0.19.2</version>
+            <version>0.21.4</version>
         </dependency>
     </dependencies>
     <build>

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
@@ -95,7 +95,7 @@ public final class Wrap {
      * @return The project
      */
     private Project project(final String basedir, final String outdir,
-        final String[] paths) {
+        final String... paths) {
         final Project project = new Project();
         for (final String jar : paths) {
             if (!jar.equals(outdir)) {

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -280,15 +280,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-invoker-plugin</artifactId>
-                <!--
-                Latest version of the plugin (1.8) is based on Groovy 2.0.1,
-                which is based on ASM 4.0, while CodeNarc and FindBugs are still using ASM 3.x.
-                This version mismatch leads to an exception in runtime,
-                explained in http://stackoverflow.com/questions/11738732/
-                That's why we downgrade the version here to 1.6, which is
-                based on Groovy 1.8.6, which is using ASM 3.2.
-                -->
-                <version>1.6</version>
                 <configuration combine.children="append">
                     <mergeUserSettings>true</mergeUserSettings>
                     <!--

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -102,6 +102,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
     /**
      * List of xpath queries to validate pom.xml.
      * @since 0.5
+     * @checkstyle IndentationCheck (5 lines)
      */
     @Parameter(
         property = "qulice.asserts",

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DuplicateFinderValidator.java
@@ -75,18 +75,18 @@ public final class DuplicateFinderValidator implements MavenValidator {
                 )
             );
             final Collection<Properties> deps = new LinkedList<Properties>();
-//            for (String sdep : env.excludes("duplicate")) {
-//                if (StringUtils.countMatches(sdep, ":") == 2) {
-//                    String[] parts = sdep.split(":");
-//                    Properties main = new Properties();
-//                    Properties prop = new Properties();
-//                    prop.put("groupId", parts[0]);
-//                    prop.put("artifactId", parts[1]);
-//                    prop.put("version", parts[2]);
-//                    main.put("dependency", prop);
-//                    deps.add(prop);
-//                }
-//            }
+            //  for (String sdep : env.excludes("duplicate")) {
+            //      if (StringUtils.countMatches(sdep, ":") == 2) {
+            //          String[] parts = sdep.split(":");
+            //          Properties main = new Properties();
+            //          Properties prop = new Properties();
+            //          prop.put("groupId", parts[0]);
+            //          prop.put("artifactId", parts[1]);
+            //          prop.put("version", parts[2]);
+            //          main.put("dependency", prop);
+            //          deps.add(prop);
+            //      }
+            //  }
             props.put("ignoredDependencies", deps);
             env.executor().execute(
                 "com.ning.maven.plugins:maven-duplicate-finder-plugin:1.0.7",

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
@@ -98,7 +98,7 @@ interface MavenEnvironment extends Environment {
          * @param penv Parent env
          * @param pmenv Parent maven env
          */
-        public Wrap(final Environment penv,
+        Wrap(final Environment penv,
             final MavenEnvironment pmenv) {
             this.env = penv;
             this.menv = pmenv;

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
@@ -57,20 +57,17 @@ public final class MavenEnvironmentMocker {
     /**
      * Project.
      */
-    private transient MavenProjectMocker prj =
-        new MavenProjectMocker();
+    private transient MavenProjectMocker prj;
 
     /**
      * Plexus container, mock.
      */
-    private final transient PlexusContainer container =
-        Mockito.mock(PlexusContainer.class);
+    private final transient PlexusContainer container;
 
     /**
      * Xpath queries to test pom.xml.
      */
-    private transient Collection<String> ass =
-        new LinkedList<String>();
+    private transient Collection<String> ass;
 
     /**
      * Public ctor.
@@ -78,6 +75,9 @@ public final class MavenEnvironmentMocker {
      */
     public MavenEnvironmentMocker() throws IOException {
         StaticLoggerBinder.getSingleton().setMavenLog(Mockito.mock(Log.class));
+        this.prj = new MavenProjectMocker();
+        this.container = Mockito.mock(PlexusContainer.class);
+        this.ass = new LinkedList<String>();
         this.ienv = new Environment.Mock();
     }
 

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
@@ -55,14 +55,14 @@ final class PmdListener implements ReportListener {
     /**
      * Violations.
      */
-    private final transient Collection<RuleViolation> violations =
-        new LinkedList<RuleViolation>();
+    private final transient Collection<RuleViolation> violations;
 
     /**
      * Public ctor.
      * @param environ Environment
      */
     PmdListener(final Environment environ) {
+        this.violations = new LinkedList<RuleViolation>();
         this.env = environ;
     }
 

--- a/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -55,7 +55,7 @@ public final class SourceValidator {
     /**
      * Rule context.
      */
-    private final transient RuleContext context = new RuleContext();
+    private final transient RuleContext context;
 
     /**
      * Report listener.
@@ -72,6 +72,7 @@ public final class SourceValidator {
      * @param env Environment
      */
     public SourceValidator(final Environment env) {
+        this.context = new RuleContext();
         this.listener = new PmdListener(env);
         this.config = new PMDConfiguration();
         this.config.setRuleSets("com/qulice/pmd/ruleset.xml");

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
@@ -300,6 +300,7 @@ public final class PMDValidatorTest {
             } catch (final ValidationException ex) {
                 valid = false;
             }
+            writer.flush();
             MatcherAssert.assertThat(valid, Matchers.is(result));
             MatcherAssert.assertThat(writer.toString(), matcher);
         } finally {

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -132,12 +132,11 @@ public interface Environment {
         /**
          * Files for classpath.
          */
-        private final transient Set<String> classpath = new HashSet<String>(0);
+        private final transient Set<String> classpath;
         /**
          * Map of params.
          */
-        private final transient ConcurrentMap<String, String> params =
-            new ConcurrentHashMap<String, String>();
+        private final transient ConcurrentMap<String, String> params;
         /**
          * Exclude patterns.
          */
@@ -148,6 +147,8 @@ public interface Environment {
          * @throws IOException If some IO problem
          */
         public Mock() throws IOException {
+            this.params = new ConcurrentHashMap<String, String>();
+            this.classpath = new HashSet<String>(0);
             final File temp = File.createTempFile(
                 "mock", ".qulice",
                 new File(System.getProperty("java.io.tmpdir"))

--- a/qulice-xml/pom.xml
+++ b/qulice-xml/pom.xml
@@ -85,6 +85,17 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-aspects</artifactId>
+            <version>0.21.1</version>
+            <!--
+            Override jcabi-aspects version for qulice-xml to 0.21.1
+            See issues https://github.com/jcabi/jcabi-aspects/issues/194
+            and https://github.com/jcabi/jcabi-xml/issues/73
+             -->
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
+++ b/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
@@ -53,11 +53,9 @@ import org.xml.sax.SAXException;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
- * @checkstyle IndentationCheck (5 lines)
  */
-@SuppressWarnings(
-    { "PMD.AvoidInstantiatingObjectsInLoops", "PMD.ExceptionAsFlowControl" }
-)
+@SuppressWarnings({ "PMD.AvoidInstantiatingObjectsInLoops",
+    "PMD.ExceptionAsFlowControl" })
 public final class XmlValidator implements Validator {
 
     /**

--- a/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
+++ b/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
@@ -53,6 +53,7 @@ import org.xml.sax.SAXException;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @checkstyle IndentationCheck (5 lines)
  */
 @SuppressWarnings(
     { "PMD.AvoidInstantiatingObjectsInLoops", "PMD.ExceptionAsFlowControl" }


### PR DESCRIPTION
Resolving #553 
* upgrade dependencies
* enforce jcabi-aspects version for qulice-xml (see issues jcabi/jcabi-aspects#194 and jcabi/jcabi-xml#73)
* qulice 0.14 compliance
* force flushing writer in PMD tests before match 