### PR TITLE
XmlValidator should properly fail XML files without schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,17 @@
             <url>http://www.qulice.com</url>
         </site>
     </distributionManagement>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Manual jcabi-xml version override until parent POM declares
+            version 0.17.1 or higher -->
+            <dependency>
+                <groupId>com.jcabi</groupId>
+                <artifactId>jcabi-xml</artifactId>
+                <version>0.17.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <pluginManagement>
             <plugins>

--- a/qulice-xml/pom.xml
+++ b/qulice-xml/pom.xml
@@ -61,7 +61,6 @@
         <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-xml</artifactId>
-            <version>0.15</version>
             <!--
              @todo #280 This version of jcabi-xml retries if the connection
               to the host of the schema document is reset. However I don't know
@@ -69,7 +68,7 @@
               should find a way to test whether it does retry if this happens.
               See issues https://github.com/jcabi/jcabi-xml/issues/32 and
               https://github.com/teamed/qulice/issues/280 for background
-              details.  
+              details.
             -->
         </dependency>
         <dependency>

--- a/qulice-xml/src/test/java/com/qulice/xml/XmlValidatorTest.java
+++ b/qulice-xml/src/test/java/com/qulice/xml/XmlValidatorTest.java
@@ -78,14 +78,13 @@ public final class XmlValidatorTest {
      */
     @Test(expected = ValidationException.class)
     public void failValidationWithoutSchema() throws Exception {
-        final Environment env = new Environment.Mock()
+        new XmlValidator(true).validate(new Environment.Mock()
             .withFile(
                 "src/main/resources/noschema.xml",
                 // @checkstyle LineLength (1 line)
                 "<Configuration><Appenders><Console name=\"CONSOLE\" target=\"SYSTEM_OUT\"><PatternLayout pattern=\"[%p] %t %c: %m%n\"/></Console></Appenders></Configuration>"
-            );
-        final Validator validator = new XmlValidator(true);
-        validator.validate(env);
+            )
+        );
     }
 
     /**

--- a/qulice-xml/src/test/java/com/qulice/xml/XmlValidatorTest.java
+++ b/qulice-xml/src/test/java/com/qulice/xml/XmlValidatorTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */
+@SuppressWarnings("PMD.TooManyMethods")
 public final class XmlValidatorTest {
 
     /**
@@ -67,6 +68,22 @@ public final class XmlValidatorTest {
                 // @checkstyle LineLength (1 line)
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<document xmlns=\"http://maven.apache.org/changes/1.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/changes/1.0.0 http://maven.apache.org/xsd/changes-1.0.0.xsd\">\n    <body/>\n</document>\n"
         );
+        final Validator validator = new XmlValidator(true);
+        validator.validate(env);
+    }
+
+    /**
+     * Should fail validation for XML without schema specified.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test(expected = ValidationException.class)
+    public void failValidationWithoutSchema() throws Exception {
+        final Environment env = new Environment.Mock()
+            .withFile(
+                "src/main/resources/noschema.xml",
+                // @checkstyle LineLength (1 line)
+                "<Configuration><Appenders><Console name=\"CONSOLE\" target=\"SYSTEM_OUT\"><PatternLayout pattern=\"[%p] %t %c: %m%n\"/></Console></Appenders></Configuration>"
+            );
         final Validator validator = new XmlValidator(true);
         validator.validate(env);
     }


### PR DESCRIPTION
Unit test for #498.

XmlValidator should properly fail XML files without schema with `ValidationException`. And it does inside `qulice-xml` module that uses `jcabi-xml` version **0.15**. `qulice-maven-plugin` on the other hand uses  `jcabi-xml` version **0.17** and fails the same test with vague `NullPoinerException`.

Easily reproducible by updating `jcabi-xml` version inside `qulice-xml/pom.xml` to **0.17**.

Probably caused by https://github.com/jcabi/jcabi-xml/issues/94.