### PR TITLE
#495 Validate all author tags in JavadocTags check

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -32,6 +32,8 @@ package com.qulice.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
@@ -114,8 +116,8 @@ public final class JavadocTagsCheck extends Check {
      */
     private void matchTagFormat(final String[] lines, final int start,
         final int end, final String tag) {
-        final int line = this.findTagLineNum(lines, start, end, tag);
-        if (line == -1) {
+        final List<Integer> found = this.findTagLineNum(lines, start, end, tag);
+        if (found.isEmpty()) {
             this.log(
                 start + 1,
                 "Missing ''@{0}'' tag in class/interface comment",
@@ -123,14 +125,16 @@ public final class JavadocTagsCheck extends Check {
             );
             return;
         }
-        final String text = this.getTagText(lines[line]);
-        if (!this.tags.get(tag).matcher(text).matches()) {
-            this.log(
-                line + 1,
-                "Tag text ''{0}'' does not match the pattern ''{1}''",
-                text,
-                this.tags.get(tag).toString()
-            );
+        for (final Integer item : found) {
+            final String text = this.getTagText(lines[item]);
+            if (!this.tags.get(tag).matcher(text).matches()) {
+                this.log(
+                    item + 1,
+                    "Tag text ''{0}'' does not match the pattern ''{1}''",
+                    text,
+                    this.tags.get(tag).toString()
+                );
+            }
         }
     }
 
@@ -154,10 +158,10 @@ public final class JavadocTagsCheck extends Check {
      * @return Line number with found tag or -1 otherwise.
      * @checkstyle ParameterNumber (3 lines)
      */
-    private int findTagLineNum(final String[] lines, final int start,
+    private List<Integer> findTagLineNum(final String[] lines, final int start,
         final int end, final String tag) {
         final String prefix = String.format(" * @%s ", tag);
-        int found = -1;
+        final List<Integer> found = new ArrayList<Integer>(1);
         for (int pos = start; pos <= end; pos += 1) {
             final String line = lines[pos];
             if (line.contains(String.format("@%s ", tag))) {
@@ -168,11 +172,9 @@ public final class JavadocTagsCheck extends Check {
                         tag,
                         prefix
                     );
-                    found = -1;
                     break;
                 }
-                found = pos;
-                break;
+                found.add(pos);
             }
         }
         return found;

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Invalid.java
@@ -15,7 +15,7 @@ public final class Invalid {
  * @author John Smith - incorrect format of author
  * @version 1.1 - incorrect format
  */
-public final class Foo {
+public final class InvalidAuthor {
 }
 
 /**
@@ -24,5 +24,13 @@ public final class Foo {
  * @author Third Author (third@author.com)
  * @version $Id$
  */
-public final class Bar {
+public final class TwoValidAndOneInvalidAuthor {
+}
+
+/**
+ * @author first author has incorrect format
+ * @author second author has incorrect format
+ * @version $Id$
+ */
+public final class TwoInvalidAuthors {
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Invalid.java
@@ -17,3 +17,12 @@ public final class Invalid {
  */
 public final class Foo {
 }
+
+/**
+ * @author First Author (first@author.com)
+ * @author second author has incorrect format
+ * @author Third Author (third@author.com)
+ * @version $Id$
+ */
+public final class Bar {
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Valid.java
@@ -5,6 +5,7 @@
 
 /**
  * @author Yegor Bugayenko (yegor@tpc2.com)
+ * @author Some Name (some@name.com)
  * @version $Id$
  */
 public final class Invalid {

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/violations.txt
@@ -2,3 +2,4 @@
 6:Missing '@version' tag in class/interface comment
 15:Tag text 'John Smith - incorrect format of author' does not match the pattern '^([A-Z](\.|[a-z]+) )+\([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\)$'
 16:Tag text '1.1 - incorrect format' does not match the pattern '^\$Id.*\$$'
+23:Tag text 'second author has incorrect format' does not match the pattern '^([A-Z](\.|[a-z]+) )+\([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\)$'

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/violations.txt
@@ -3,3 +3,5 @@
 15:Tag text 'John Smith - incorrect format of author' does not match the pattern '^([A-Z](\.|[a-z]+) )+\([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\)$'
 16:Tag text '1.1 - incorrect format' does not match the pattern '^\$Id.*\$$'
 23:Tag text 'second author has incorrect format' does not match the pattern '^([A-Z](\.|[a-z]+) )+\([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\)$'
+31:Tag text 'first author has incorrect format' does not match the pattern '^([A-Z](\.|[a-z]+) )+\([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\)$'
+32:Tag text 'second author has incorrect format' does not match the pattern '^([A-Z](\.|[a-z]+) )+\([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}\)$'


### PR DESCRIPTION
 For #495:
 * Instead of validating only first Javadoc tag, all of them are gathered to the `List` and then validated
 * Test is added to confirm the behaviour