### PR TITLE
#421 Add test for multiline exclusion for FindBugs

### DIFF
--- a/qulice-maven-plugin/src/it/findbugs-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/findbugs-exclude/pom.xml
@@ -47,12 +47,8 @@
                 <configuration>
                     <license>file:./LICENSE.txt</license>
                     <excludes>
-						<!--
-                         @todo #352 Need to add multiline check after issue #350
-                          resolved. Now only one class can be excluded
-                          Don't forget update example-exclude.apt.vm
-						-->
-                        <exclude>findbugs:~com.qulice.foo.*</exclude>
+                        <exclude>findbugs:~com.qulice.foo.M.*</exclude>
+                        <exclude>findbugs:com.qulice.foo.Bar</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
@@ -53,6 +53,7 @@ Exclude
         <excludes>
           <exclude>checkstyle:/src/examples/.*</exclude>
           <exclude>findbugs:~com.qulice.foo.*</exclude>
+          <exclude>findbugs:com.qulice.bar.Baz</exclude>
         </excludes>
       </configuration>
     </plugin>
@@ -85,4 +86,3 @@ Exclude
   2) <<<findbugs:com.qulice.foo.Bar>>> excludes only class Bar in appropriate
   packages.
   See http://findbugs.sourceforge.net/manual/filter.html
-  Only one exclude is supported for findbugs.


### PR DESCRIPTION
For #421:
* Add two separate exclusions instead of one in integration test (we have two files with violations already, test is failing when leaving just one of them)
* Remove puzzle from the code
* Adjust documentation