### PR TITLE
#581 Configure pdd and est in Travis and Rultor

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -3,7 +3,8 @@ architect:
 - yegor256
 - davvd
 install:
-- sudo gem install pdd
+- sudo gem install --no-ri --no-rdoc pdd
+- sudo gem install --no-ri --no-rdoc est
 assets:
   secring.gpg: yegor256/home#assets/secring.gpg
   settings.xml: yegor256/home#assets/qulice/settings.xml
@@ -15,6 +16,7 @@ merge:
     mvn clean site -Psite --errors --settings ../settings.xml
     mvn clean
     pdd --source=$(pwd) --verbose --file=/dev/null --exclude=qulice-maven-plugin/src/it/**/*.java
+    est --dir=est --file=/dev/null
   commanders:
   - caarlos0
   - carlosmiranda

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ install:
   - travis_retry sudo apt-get install -y --fix-missing libmagic1 libmagic-dev
   - gem install --no-ri --no-rdoc pdd
   - gem install --no-ri --no-rdoc est
+  - set +e
 script:
+  - set -e
   - pdd --file=/dev/null --exclude=qulice-maven-plugin/src/it/**/*.java
   - est --dir=est --file=/dev/null
   - mvn clean install -Pqulice --errors
+  - set +e

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ install:
   - gem install --no-ri --no-rdoc pdd
   - gem install --no-ri --no-rdoc est
 script:
-  - pdd --file=/dev/null
+  - pdd --file=/dev/null --exclude=qulice-maven-plugin/src/it/**/*.java
   - est --dir=est --file=/dev/null
   - mvn clean install -Pqulice --errors

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,12 @@ env:
   global:
     - MAVEN_OPTS="-XX:MaxPermSize=2g -Xmx4g"
     - JAVA_OPTS="-XX:MaxPermSize=2g -Xmx4g"
+install:
+  - set -e
+  - travis_retry sudo apt-get install -y --fix-missing libmagic1 libmagic-dev
+  - gem install --no-ri --no-rdoc pdd
+  - gem install --no-ri --no-rdoc est
 script:
   - mvn clean install -Pqulice --errors
+  - pdd --file=/dev/null
+  - est --dir=est --file=/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ install:
   - gem install --no-ri --no-rdoc pdd
   - gem install --no-ri --no-rdoc est
 script:
-  - mvn clean install -Pqulice --errors
   - pdd --file=/dev/null
   - est --dir=est --file=/dev/null
+  - mvn clean install -Pqulice --errors


### PR DESCRIPTION
For #581:
* Rultor config (based on various examples from search https://github.com/search?utf8=%E2%9C%93&q=gem+install+est+filename%3A.rultor.yml&type=Code&ref=searchresults):
 * install est
 * make install faster for pdd by skipping docs
 * add estimates check
 * add missing newline at the end of file 
* Travis config
 * install pdd and est with `set -e` (based on https://github.com/jcabi/jcabi-dynamo/blob/6ab5f80beb9b3016cbd818cf6c3ef77c6ddddee0/.travis.yml and https://github.com/yegor256/s3auth/blob/a2f7cc35e407d9d43051351100baabf1ee42e312/.travis.yml)
 * invoke pdd and est