### PR TITLE
#376 Modify rules for local variable names

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -310,10 +310,14 @@
         <module name="ClassTypeParameterName"/>
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName">
-            <property name="format" value="^ex|[a-z]{3,}$"/>
+            <property name="format" value="^[a-z]{3,12}$"/>
+            <property name="tokens" value="VARIABLE_DEF"/>
         </module>
         <module name="LocalVariableName">
-            <property name="format" value="^ex|[a-z]{3,}$"/>
+            <property name="format" value="^[a-z]{3,12}$"/>
+        </module>
+        <module name="CatchParameterName">
+            <property name="format" value="^ex|[a-z]{3,12}$"/>
         </module>
         <module name="MemberName">
             <property name="format" value="^[a-z]{3,}$"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -33,6 +33,7 @@ import com.qulice.spi.Environment;
 import com.qulice.spi.ValidationException;
 import java.io.File;
 import java.io.StringWriter;
+import java.util.Arrays;
 import org.apache.commons.io.IOUtils;
 import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.WriterAppender;
@@ -250,6 +251,40 @@ public final class CheckstyleValidatorTest {
                 Matchers.not(
                     Matchers.containsString(
                         "ConstructorParams.java[21]: 'number' hides a field."
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * CheckstyleValidator allows local variables and catch parameters with
+     * names matching {@code ^[a-z]{3,12}$} pattern.
+     * Additionally, catch parameters can use name {@code ex}.
+     * @throws Exception In case of error
+     */
+    @Test
+    public void allowsOnlyProperlyNamedLocalVariables() throws Exception {
+        this.validateCheckstyle(
+            "LocalVariableNames.java", false,
+            Matchers.allOf(
+                Matchers.not(
+                    Matchers.stringContainsInOrder(
+                        Arrays.asList(
+                            "aaa", "twelveletter", "ise"
+                        )
+                    )
+                ),
+                Matchers.stringContainsInOrder(
+                    Arrays.asList(
+                        "LocalVariableNames.java",
+                        "Name 'prolongations' must match pattern",
+                        "Name 'camelCase' must match pattern '^[a-z]{3,12}$'.",
+                        "Name 'number1' must match pattern '^[a-z]{3,12}$'.",
+                        "Name 'ex' must match pattern '^[a-z]{3,12}$'.",
+                        "Name 'a' must match pattern '^[a-z]{3,12}$'.",
+                        "Name 'ae' must match pattern '^ex|[a-z]{3,12}$'.",
+                        "Name 'e' must match pattern '^ex|[a-z]{3,12}$'."
                     )
                 )
             )

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -29,12 +29,15 @@
  */
 package com.qulice.checkstyle;
 
+import com.jcabi.aspects.Tv;
 import com.qulice.spi.Environment;
 import com.qulice.spi.ValidationException;
 import java.io.File;
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Arrays;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.SimpleLayout;
 import org.apache.log4j.WriterAppender;
 import org.hamcrest.Matcher;
@@ -265,8 +268,15 @@ public final class CheckstyleValidatorTest {
      */
     @Test
     public void allowsOnlyProperlyNamedLocalVariables() throws Exception {
-        this.validateCheckstyle(
-            "LocalVariableNames.java", false,
+        final String result = this.runValidation(
+            "LocalVariableNames.java", false
+        );
+        MatcherAssert.assertThat(
+            StringUtils.countMatches(result, "LocalVariableNames.java"),
+            Matchers.is(Tv.SEVEN)
+        );
+        MatcherAssert.assertThat(
+            result,
             Matchers.allOf(
                 Matchers.not(
                     Matchers.stringContainsInOrder(
@@ -277,7 +287,6 @@ public final class CheckstyleValidatorTest {
                 ),
                 Matchers.stringContainsInOrder(
                     Arrays.asList(
-                        "LocalVariableNames.java",
                         "Name 'prolongations' must match pattern",
                         "Name 'camelCase' must match pattern '^[a-z]{3,12}$'.",
                         "Name 'number1' must match pattern '^[a-z]{3,12}$'.",
@@ -362,6 +371,18 @@ public final class CheckstyleValidatorTest {
      */
     private void validateCheckstyle(final String file, final boolean result,
         final Matcher<String> matcher) throws Exception {
+        MatcherAssert.assertThat(this.runValidation(file, result), matcher);
+    }
+
+    /**
+     * Returns string with Checkstyle validation results.
+     * @param file File to check.
+     * @param result Expected validation result.
+     * @return String containing validation results in textual form.
+     * @throws IOException In case of error
+     */
+    private String runValidation(final String file, final boolean result)
+        throws IOException {
         final Environment.Mock mock = new Environment.Mock();
         final File license = this.rule.savePackageInfo(
             new File(mock.basedir(), CheckstyleValidatorTest.DIRECTORY)
@@ -388,6 +409,6 @@ public final class CheckstyleValidatorTest {
             valid = false;
         }
         MatcherAssert.assertThat(valid, Matchers.is(result));
-        MatcherAssert.assertThat(writer.toString(), matcher);
+        return writer.toString();
     }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
@@ -1,0 +1,48 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+public final class LocalVariableNames {
+    /**
+     * Just a field.
+     */
+    private transient int field;
+
+    /**
+     * Names that should not cause any violation.
+     */
+    void valid() {
+        try {
+            int aaa = this.field;
+            final int twelveletter = ++aaa;
+        } catch (final IllegalStateException ise) {
+            throw ise;
+        } catch (final IllegalArgumentException ex) {
+            throw ex;
+        }
+    }
+
+    /**
+     * Each name here should cause one violation.
+     */
+    void invalid() {
+        try {
+            int prolongations = 0;
+            int camelCase = this.field;
+            final int number1 = ++prolongations;
+            final int ex = ++camelCase;
+            final int a = 0;
+        } catch (final ArithmeticException ae) {
+            throw ae;
+        } catch (final IllegalArgumentException e) {
+            throw e;
+        }
+    }
+}
+

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
@@ -29,7 +29,7 @@ public final class LocalVariableNames {
     }
 
     /**
-     * Each name here should cause one violation.
+     * Each of those seven names here should cause violation.
      */
     void invalid() {
         try {


### PR DESCRIPTION
For #376:
* Limit local variables and catch parameters to 12 chars
* Remove `ex` from `LocalVariableName`, as this check from Checkstyle 6.14 doesn't validate catch parameters anymore
* Disable catch parameters validation in `LocalFinalVariableName` by setting property `tokens` to `VARIABLE_DEF`
* Add `CatchParameterName` introduced in Checkstyle 6.14 with pattern same as it was previously used for local variables
* Add test with input file