### PR TITLE
#592 Enable LineLength check for Javadoc tags

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -339,7 +339,7 @@
         </module>
         <module name="LineLength">
             <property name="max" value="80"/>
-            <property name="ignorePattern" value="^((\s+(\*|//)\s+@[a-z]+ )|(import )).*$"/>
+            <property name="ignorePattern" value="^import .*$"/>
         </module>
         <module name="AnonInnerLength" />
         <module name="MethodLength"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -170,6 +170,27 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator reports an error when indentation is not
+     * bigger than previous line by exactly 4.
+     * @throws Exception when error.
+     */
+    @Test
+    public void reportsErrorWhenCommentOrJavadocIsTooLong() throws Exception {
+        this.validateCheckstyle(
+            "TooLongLines.java",
+            false,
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    "TooLongLines.java[8]",
+                    "Line is longer than 80 characters (found 82)",
+                    "TooLongLines.java[14]",
+                    "Line is longer than 80 characters (found 85)"
+                )
+            )
+        );
+    }
+
+    /**
      * CheckstyleValidator accepts the valid indentation
      * refused by forceStrictCondition.
      * @throws Exception when error.

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -170,8 +170,8 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
-     * CheckstyleValidator reports an error when indentation is not
-     * bigger than previous line by exactly 4.
+     * CheckstyleValidator reports an error when comment or Javadoc has too
+     * long line.
      * @throws Exception when error.
      */
     @Test

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/TooLongLines.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/TooLongLines.java
@@ -1,0 +1,15 @@
+/**
+ * Hello.
+ */
+package foo.bar;
+
+/**
+ * Very long lines.
+ * @deprecated Very very very very very very very very very very very long reason.
+ * @version $Id$
+ * @author John Smith (john@example.com)
+ */
+@Deprecated
+public class TooLongLines {
+    // @deprecated is used here because of very very very very very very long reason.
+}


### PR DESCRIPTION
For #592:
* enable line length check for Javadoc tags by removing it from ignored pattern
* provide test to verify that too long comments are not ignored