### PR TITLE
#595 Ignore '@Override' methods in NonStaticMethod check

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -32,6 +32,7 @@ package com.qulice.checkstyle;
 import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.utils.AnnotationUtility;
 import java.util.regex.Pattern;
 
 /**
@@ -40,6 +41,11 @@ import java.util.regex.Pattern;
  *
  * <p>If your method doesn't need {@code this} than why it is not
  * {@code static}?
+ *
+ * The only case when method can't be marked as static is when it has
+ * {@code @Override} annotation. There's no concept of inheritance and
+ * polymorphism for static methods even if they don't need {@code this} to
+ * perform the actual work.
  *
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
@@ -81,7 +87,8 @@ public final class NonStaticMethodCheck extends Check {
     }
 
     /**
-     * Check that non static class method refer \"this\".
+     * Check that non static class method refer \"this\". Methods annotated
+     * with {@code @Override} are excluded.
      * @param method DetailAST of method
      */
     private void checkClassMethod(final DetailAST method) {
@@ -90,7 +97,8 @@ public final class NonStaticMethodCheck extends Check {
         if (modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null) {
             return;
         }
-        if (!method.branchContains(TokenTypes.LITERAL_THIS)) {
+        if (!AnnotationUtility.containsAnnotation(method, "Override")
+            && !method.branchContains(TokenTypes.LITERAL_THIS)) {
             final int line = method.getLineNo();
             this.log(
                 line,

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Invalid.java
@@ -9,4 +9,8 @@ public class InvalidTest {
     public String name() {
         return "this";
     }
+    @Deprecated
+    public String name() {
+        return "method with non-overide annotation";
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
@@ -22,3 +22,10 @@ public interface Foo {
         // this method is not static, but it's a unit test
     }
 }
+
+public class Bar {
+    @Override
+    public void someMethod() {
+        // this method is not static, but it has "@Override" annotation
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/violations.txt
@@ -1,2 +1,3 @@
 6:This method must be static, because it does not refer to "this"
 9:This method must be static, because it does not refer to "this"
+12:This method must be static, because it does not refer to "this"


### PR DESCRIPTION
For #595:
* Added sample with method with `@Override` that should not cause violation despite not referencing `this`
* Added sample with method with other annotation that cause violation
* Provided additional documentation
* Implementation was pretty straightforward - just one more condition added