### PR TITLE
#603 Ignore abstract and native methods in NonStaticMethod check

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -42,10 +42,13 @@ import java.util.regex.Pattern;
  * <p>If your method doesn't need {@code this} than why it is not
  * {@code static}?
  *
- * The only case when method can't be marked as static is when it has
- * {@code @Override} annotation. There's no concept of inheritance and
- * polymorphism for static methods even if they don't need {@code this} to
- * perform the actual work.
+ * The exception here is when method has {@code @Override} annotation. There's
+ * no concept of inheritance and polymorphism for static methods even if they
+ * don't need {@code this} to perform the actual work.
+ *
+ * Another exception is when method is {@code abstract} or {@code native}.
+ * Such methods don't have body so detection based on {@code this} doesn't
+ * make sense for them.
  *
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
@@ -87,8 +90,9 @@ public final class NonStaticMethodCheck extends Check {
     }
 
     /**
-     * Check that non static class method refer \"this\". Methods annotated
-     * with {@code @Override} are excluded.
+     * Check that non static class method refer {@code this}. Methods that
+     * are {@code native}, {@code abstract} or annotated with {@code @Override}
+     * are excluded.
      * @param method DetailAST of method
      */
     private void checkClassMethod(final DetailAST method) {
@@ -98,6 +102,7 @@ public final class NonStaticMethodCheck extends Check {
             return;
         }
         if (!AnnotationUtility.containsAnnotation(method, "Override")
+            && !isInAbstractOrNativeMethod(method)
             && !method.branchContains(TokenTypes.LITERAL_THIS)) {
             final int line = method.getLineNo();
             this.log(
@@ -106,5 +111,16 @@ public final class NonStaticMethodCheck extends Check {
                 "This method must be static, because it does not refer to \"this\""
             );
         }
+    }
+
+    /**
+     * Determines whether a method is {@code abstract} or {@code native}.
+     * @param method Method to check.
+     * @return True if method is abstract or native.
+     */
+    private static boolean isInAbstractOrNativeMethod(final DetailAST method) {
+        final DetailAST modifiers = method.findFirstToken(TokenTypes.MODIFIERS);
+        return modifiers.branchContains(TokenTypes.ABSTRACT)
+            || modifiers.branchContains(TokenTypes.LITERAL_NATIVE);
     }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Invalid.java
@@ -13,4 +13,7 @@ public class InvalidTest {
     public String name() {
         return "method with non-overide annotation";
     }
+    public synchronized String name() {
+        return "method with non-native and non-abstract modifier";
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
@@ -29,11 +29,9 @@ public class Bar {
         // this method is not static, but it has "@Override" annotation
     }
 
-    public abstract void someAbstractMethod() {
-        // this method is not static, but it is abstract
-    }
+    // this method is not static, but it is abstract
+    public abstract void someAbstractMethod();
 
-    public native void someNativeMethod() {
-        // this method is not static, but it is native
-    }
+    // this method is not static, but it is native
+    public native void someNativeMethod();
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
@@ -25,7 +25,15 @@ public interface Foo {
 
 public class Bar {
     @Override
-    public void someMethod() {
+    public void someOverrideMethod() {
         // this method is not static, but it has "@Override" annotation
+    }
+
+    public abstract void someAbstractMethod() {
+        // this method is not static, but it is abstract
+    }
+
+    public native void someNativeMethod() {
+        // this method is not static, but it is native
     }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/violations.txt
@@ -1,3 +1,4 @@
 6:This method must be static, because it does not refer to "this"
 9:This method must be static, because it does not refer to "this"
 12:This method must be static, because it does not refer to "this"
+16:This method must be static, because it does not refer to "this"

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -294,7 +294,6 @@ public interface Environment {
             return files;
         }
         @Override
-        // @checkstyle NonStaticMethod (1 line)
         public boolean exclude(final String check, final String name) {
             return false;
         }


### PR DESCRIPTION
For #603:
* excluded native and abstract methods from the check
* provided positive and negative test case
* removed obsolete suppression related to `@Override`