### PR TITLE
#609 Remove unnecessary usages of 'ConcurrentHashMap'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
                         <plugin>
                             <groupId>com.qulice</groupId>
                             <artifactId>qulice-maven-plugin</artifactId>
-                            <version>0.15.1</version>
+                            <version>0.15.2</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -33,9 +33,9 @@ import com.puppycrawl.tools.checkstyle.api.Check;
 import com.puppycrawl.tools.checkstyle.api.DetailAST;
 import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -69,8 +69,8 @@ public final class JavadocTagsCheck extends Check {
     /**
      * Map of tag and its pattern.
      */
-    private final transient ConcurrentMap<String, Pattern> tags =
-        new ConcurrentHashMap<String, Pattern>();
+    private final transient Map<String, Pattern> tags =
+        new HashMap<String, Pattern>();
 
     @Override
     public void init() {

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -82,8 +82,7 @@ public final class UnnecessaryLocalRule extends AbstractJavaRule {
      * @param data Context.
      * @param name Variable name.
      */
-    @SuppressWarnings({ "PMD.AvoidInstantiatingObjectsInLoops",
-        "PMD.UseConcurrentHashMap" })
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     private void usages(final JavaNode node, final Object data,
         final ASTVariableDeclarator name) {
         final Map<NameDeclaration, List<NameOccurrence>> vars = name

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PMDDisabledRulesTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PMDDisabledRulesTest.java
@@ -41,10 +41,6 @@ import org.junit.runners.Parameterized;
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
  * @since 0.16
- * @todo #569:15min When new version of Qulice is released (with disabled rules:
- *  UseConcurrentHashMap, DoNotUseThreads and AvoidUsingVolatile) remove
- *  suppression of given rules and remove unneeded usages of ConcurrentMap and
- *  ConcurrentHashMap.
  */
 @RunWith(Parameterized.class)
 public final class PMDDisabledRulesTest {

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -34,11 +34,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.IOFileFilter;
@@ -137,7 +137,7 @@ public interface Environment {
         /**
          * Map of params.
          */
-        private final transient ConcurrentMap<String, String> params;
+        private final transient Map<String, String> params;
         /**
          * Exclude patterns.
          */
@@ -151,7 +151,7 @@ public interface Environment {
             "PMD.ConstructorOnlyInitializesOrCallOtherConstructors"
             )
         public Mock() throws IOException {
-            this.params = new ConcurrentHashMap<String, String>();
+            this.params = new HashMap<String, String>();
             this.classpath = new HashSet<String>(1);
             final File temp = File.createTempFile(
                 "mock", ".qulice",


### PR DESCRIPTION
For #609:
* update Qulice to 0.15.2
* replace usages of `ConcurrentHashMap` with `HashMap`
* remove suppression
* remove puzzle