### PR TITLE
#371 Prohibit multi-line comments in MethodBodyComments check

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
@@ -103,7 +103,7 @@ public final class MethodBodyCommentsCheck extends Check {
         final boolean oneliner = start == end - 1;
         for (int pos = start; pos < end; ++pos) {
             final String line = lines[pos].trim();
-            if (line.startsWith("//")) {
+            if (line.startsWith("//") || line.startsWith("/*")) {
                 final String comment = line.substring(2).trim();
                 if (!comment.startsWith("@checkstyle") && !oneliner) {
                     this.log(pos + 1, "Comments in method body are prohibited");

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Invalid.java
@@ -7,12 +7,20 @@ public final class Invalid {
      * Comments.
      */
     public Invalid(String name, String value) {
+        /* Comments */
         int i;
         // Comments
     }
     public void print(String format, String text) {
         // Comments
         int c = 0;
+        /* Comments */
+    }
+
+    public int invalidCommentInside() {
+        final int first = 1;
+/* invalid comment */ final int second = 2;
+        return first + second;
     }
 }
 

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Invalid.java
@@ -22,5 +22,21 @@ public final class Invalid {
 /* invalid comment */ final int second = 2;
         return first + second;
     }
+
+    public int invalidMultilineInside() {
+        /**
+         * invalid multiline comment
+         */
+    }
+
+    void submit() {
+        new Runnable() {
+            @Override
+            public void run() {
+                /* run
+                 */
+            }
+        };
+    }
 }
 

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/Valid.java
@@ -50,4 +50,8 @@ public interface ValidInterface {
      * Some method with no body
      */
     void method();
+
+    /* Some plain comment outside method*/
+    void method();
+    /* Another plain comment outside method */
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/violations.txt
@@ -3,3 +3,5 @@
 15:Comments in method body are prohibited
 17:Comments in method body are prohibited
 22:Comments in method body are prohibited
+27:Comments in method body are prohibited
+36:Comments in method body are prohibited

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/MethodBodyCommentsCheck/violations.txt
@@ -1,2 +1,5 @@
-11:Comments in method body are prohibited
-14:Comments in method body are prohibited
+10:Comments in method body are prohibited
+12:Comments in method body are prohibited
+15:Comments in method body are prohibited
+17:Comments in method body are prohibited
+22:Comments in method body are prohibited


### PR DESCRIPTION
For #371:
* add one condition to implementation
* extend tests with various cases