### PR TITLE
#611 Static constants are not checked to have class specified

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -167,5 +167,22 @@
         <priority>3</priority>
     </rule>
 
-
+    <rule name="StaticAccessToStaticFields"
+          message="Static fields should be accessed in a static way [CLASS_NAME.FIELD_NAME]."
+          language="java"
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            Avoid accessing static fields directly.
+        </description>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+                            //Name[@Image = //FieldDeclaration[@Static='true']/@VariableName]
+                    ]]>
+                </value>
+            </property>
+        </properties>
+        <priority>3</priority>
+    </rule>
 </ruleset>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
@@ -52,6 +52,13 @@ import org.junit.Test;
 public final class PMDValidatorTest {
 
     /**
+     * Error message for forbidding access to static fields
+     * other than with a static way.
+     * @checkstyle LineLength (2 lines)
+     */
+    private static final String STATIC_ACCESS = "%s\\[\\d+-\\d+\\]: Static fields should be accessed in a static way \\[CLASS_NAME.FIELD_NAME\\]\\.";
+
+    /**
      * Error message for forbidding instructions inside a constructor
      * other than field initialization or call to other contructors.
      * @checkstyle LineLength (2 lines)
@@ -312,6 +319,42 @@ public final class PMDValidatorTest {
                 RegexMatchers.containsPattern(
                     String.format(PMDValidatorTest.CODE_IN_CON, file)
                 )
+            )
+        ).validate();
+    }
+
+    /**
+     * PMDValidator accepts calls to static fields
+     * in a static way.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void acceptsCallToStaticFieldsInStaticWay()
+        throws Exception {
+        final String file = "StaticAccessToStaticFields.java";
+        new PMDAssert(
+            file, Matchers.is(true),
+            Matchers.not(
+                RegexMatchers.containsPattern(
+                    String.format(PMDValidatorTest.STATIC_ACCESS, file)
+                )
+            )
+        ).validate();
+    }
+
+    /**
+     * PMDValidator forbids calls to static fields
+     * in a non static way.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void forbidsCallToStaticFieldsInNonStaticWay()
+        throws Exception {
+        final String file = "NonStaticAccessToStaticFields.java";
+        new PMDAssert(
+            file, Matchers.is(false),
+            RegexMatchers.containsPattern(
+                String.format(PMDValidatorTest.STATIC_ACCESS, file)
             )
         ).validate();
     }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/NonStaticAccessToStaticFields.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/NonStaticAccessToStaticFields.java
@@ -1,0 +1,13 @@
+package foo;
+
+public final class NonStaticAccessToStaticFields {
+    private static int num = 1;
+
+    public static int number() {
+        return num;
+    }
+
+    public int another() {
+        return 0;
+    }
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/StaticAccessToStaticFields.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/StaticAccessToStaticFields.java
@@ -1,0 +1,13 @@
+package foo;
+
+public final class StaticAccessToStaticFields {
+    private static int num = 1;
+
+    public static int number() {
+        return StaticAccessToStaticFields.num;
+    }
+
+    public int another() {
+        return 0;
+    }
+}


### PR DESCRIPTION
Resolving #611 by PMD XPath rule.
Added A positive and a negative unit test.