### PR TITLE
Allowing variables with minimum 2 characters

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -310,17 +310,17 @@
         <module name="ClassTypeParameterName"/>
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName">
-            <property name="format" value="^[a-z]{3,12}$"/>
+            <property name="format" value="^id$|^[a-z]{3,12}$"/>
             <property name="tokens" value="VARIABLE_DEF"/>
         </module>
         <module name="LocalVariableName">
-            <property name="format" value="^[a-z]{3,12}$"/>
+            <property name="format" value="^id$|^[a-z]{3,12}$"/>
         </module>
         <module name="CatchParameterName">
             <property name="format" value="^ex|[a-z]{3,12}$"/>
         </module>
         <module name="MemberName">
-            <property name="format" value="^[a-z]{3,}$"/>
+            <property name="format" value="^id$|^[a-z]{3,12}$"/>
         </module>
         <module name="MethodName">
             <property name="format" value="^[a-z]{2,}[a-zA-Z]+$"/>

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -328,7 +328,7 @@
         <module name="MethodTypeParameterName"/>
         <module name="PackageName"/>
         <module name="ParameterName">
-            <property name="format" value="^[a-z]{3,}$"/>
+            <property name="format" value="^id$|^[a-z]{3,}$"/>
         </module>
         <module name="StaticVariableName"/>
         <module name="TypeName"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -294,7 +294,7 @@ public final class CheckstyleValidatorTest {
         );
         MatcherAssert.assertThat(
             StringUtils.countMatches(result, "LocalVariableNames.java"),
-            Matchers.is(Tv.NINE)
+            Matchers.is(Tv.TEN)
         );
         MatcherAssert.assertThat(
             result,
@@ -302,7 +302,7 @@ public final class CheckstyleValidatorTest {
                 Matchers.not(
                     Matchers.stringContainsInOrder(
                         Arrays.asList(
-                            "aaa", "twelveletter", "ise", "id"
+                            "aaa", "twelveletter", "ise", "id", "parametername"
                         )
                     )
                 ),
@@ -316,7 +316,8 @@ public final class CheckstyleValidatorTest {
                         "Name 'ex' must match pattern '^id$|^[a-z]{3,12}$'.",
                         "Name 'a' must match pattern '^id$|^[a-z]{3,12}$'.",
                         "Name 'ae' must match pattern '^ex|[a-z]{3,12}$'.",
-                        "Name 'e' must match pattern '^ex|[a-z]{3,12}$'."
+                        "Name 'e' must match pattern '^ex|[a-z]{3,12}$'.",
+                        "Name 'it' must match pattern '^id$|^[a-z]{3,}$'."
                     )
                 )
             )

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -294,7 +294,7 @@ public final class CheckstyleValidatorTest {
         );
         MatcherAssert.assertThat(
             StringUtils.countMatches(result, "LocalVariableNames.java"),
-            Matchers.is(Tv.SEVEN)
+            Matchers.is(Tv.NINE)
         );
         MatcherAssert.assertThat(
             result,
@@ -302,17 +302,19 @@ public final class CheckstyleValidatorTest {
                 Matchers.not(
                     Matchers.stringContainsInOrder(
                         Arrays.asList(
-                            "aaa", "twelveletter", "ise"
+                            "aaa", "twelveletter", "ise", "id"
                         )
                     )
                 ),
                 Matchers.stringContainsInOrder(
                     Arrays.asList(
                         "Name 'prolongations' must match pattern",
-                        "Name 'camelCase' must match pattern '^[a-z]{3,12}$'.",
-                        "Name 'number1' must match pattern '^[a-z]{3,12}$'.",
-                        "Name 'ex' must match pattern '^[a-z]{3,12}$'.",
-                        "Name 'a' must match pattern '^[a-z]{3,12}$'.",
+                        "Name 'very_long_variable_id' must match pattern",
+                        "Name 'camelCase' must match pattern",
+                        "Name 'it' must match pattern '^id$|^[a-z]{3,12}$'.",
+                        "Name 'number1' must match pattern",
+                        "Name 'ex' must match pattern '^id$|^[a-z]{3,12}$'.",
+                        "Name 'a' must match pattern '^id$|^[a-z]{3,12}$'.",
                         "Name 'ae' must match pattern '^ex|[a-z]{3,12}$'.",
                         "Name 'e' must match pattern '^ex|[a-z]{3,12}$'."
                     )

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
@@ -7,6 +7,7 @@ package foo;
  * Simple.
  * @version $Id$
  * @author John Smith (john@example.com)
+ * @checkstyle HiddenField (100 lines)
  * @since 1.0
  */
 public final class LocalVariableNames {
@@ -14,6 +15,10 @@ public final class LocalVariableNames {
      * Just a field.
      */
     private transient int field;
+    /**
+     * Just an id.
+     */
+    private transient int id;
 
     /**
      * Names that should not cause any violation.
@@ -21,7 +26,9 @@ public final class LocalVariableNames {
     void valid() {
         try {
             int aaa = this.field;
-            final int twelveletter = ++aaa;
+            int id = ++aaa;
+            final int ise = 0;
+            final int twelveletter = ++aaa + ++id;
         } catch (final IllegalStateException ise) {
             throw ise;
         } catch (final IllegalArgumentException ex) {
@@ -35,10 +42,12 @@ public final class LocalVariableNames {
     void invalid() {
         try {
             int prolongations = 0;
+            int very_long_variable_id = 0;
             int camelCase = this.field;
+            int it = 0;
             final int number1 = ++prolongations;
             final int ex = ++camelCase;
-            final int a = 0;
+            final int a = ++it + ++very_long_variable_id;
         } catch (final ArithmeticException ae) {
             throw ae;
         } catch (final IllegalArgumentException e) {
@@ -46,4 +55,3 @@ public final class LocalVariableNames {
         }
     }
 }
-

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/LocalVariableNames.java
@@ -21,6 +21,27 @@ public final class LocalVariableNames {
     private transient int id;
 
     /**
+     * Just a valid method.
+     *
+     * @param id
+     *  A valid parameter with name 'id'.
+     * @return Some value
+     */
+    static int validone(final int id) {
+        return id + 1;
+    }
+
+    /**
+     * Another valid method.
+     * @param parametername Another parameter that's valid.
+     */
+    static void validtwo(final int parametername) {
+        if (parametername == 1) {
+            throw new RuntimeException("Some error");
+        }
+    }
+
+    /**
      * Names that should not cause any violation.
      */
     void valid() {
@@ -53,5 +74,16 @@ public final class LocalVariableNames {
         } catch (final IllegalArgumentException e) {
             throw e;
         }
+    }
+
+    /**
+     * Just an invalid method that test all cases.
+     *
+     * @param it
+     *  An invalid parameter with name 'it'.
+     * @return Some value
+     */
+    static int invalid(final int it) {
+        return it + 1;
     }
 }


### PR DESCRIPTION
Solving issue #593

How I solved it

allowing 'id' or 3 to 12 characters at final, non final local variables and member names.
allowing 'id' or at leat 3 characters at method parameters names
refactoring test to match new restrictions.
ignoring 'FinalLocalVariable' check when testing the variables names (we don't need to test it here)