### PR TITLE
#578 fix Page 'qulice.com' is currently broken

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,13 +166,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.github.github</groupId>
-                <artifactId>site-maven-plugin</artifactId>
-                <configuration>
-                    <path>${project.artifactId}</path>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/qulice-ant/pom.xml
+++ b/qulice-ant/pom.xml
@@ -161,6 +161,13 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -88,6 +88,13 @@
                     <argLine>-Duser.language=en -Duser.country=US</argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/qulice-codenarc/pom.xml
+++ b/qulice-codenarc/pom.xml
@@ -81,6 +81,17 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>qulice</id>

--- a/qulice-findbugs/pom.xml
+++ b/qulice-findbugs/pom.xml
@@ -188,6 +188,13 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/qulice-gradle-plugin/pom.xml
+++ b/qulice-gradle-plugin/pom.xml
@@ -92,6 +92,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -356,6 +356,13 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/qulice-pmd/pom.xml
+++ b/qulice-pmd/pom.xml
@@ -95,7 +95,14 @@
                 <configuration>
                     <parallel>classes</parallel>
                 </configuration>
-            </plugin>            
+            </plugin>      
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/qulice-spi/pom.xml
+++ b/qulice-spi/pom.xml
@@ -49,4 +49,15 @@
             <artifactId>commons-io</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/qulice-xml/pom.xml
+++ b/qulice-xml/pom.xml
@@ -96,4 +96,15 @@
             <scope>runtime</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Resolving #578. Replace configuration in submodules only.
Pages for qulice should stay at root.