### PR TITLE
#398 added exludes for dependencies

### DIFF
--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -295,6 +295,7 @@
                         <pomInclude>findbugs-exclude/pom.xml</pomInclude>
                         <pomInclude>findbugs-violations/pom.xml</pomInclude>
                         <pomInclude>dependency-violations/pom.xml</pomInclude>
+                        <pomInclude>dependency-violations-exclude/pom.xml</pomInclude>
                         <pomInclude>multi-module/pom.xml</pomInclude>
                         <pomInclude>multi-run/pom.xml</pomInclude>
                         <pomInclude>relocation/pom.xml</pomInclude>

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/LICENSE.txt
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/LICENSE.txt
@@ -1,0 +1,2 @@
+Some text.
+And other.

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/invoker.properties
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean verify

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/pom.xml
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<!--
+ *
+ * Copyright (c) 2011-2016, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @version $Id$
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.qulice.plugin</groupId>
+    <artifactId>dependency-violations-exclude</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>dependency-violations-exclude</name>
+    <dependencies>
+        <dependency>
+            <!--
+            This dependency is never used in the project and Qulice has
+            to spot this problem and report it.
+            -->
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <!--
+            This dependency is never used in the project and Qulice has
+            to spot this problem and report it.
+            -->
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
+        <dependency>
+            <!--
+            This dependency is used and qulice should not report about it.
+            -->
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.0.1</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.qulice</groupId>
+                <artifactId>qulice-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <license>file:${basedir}/LICENSE.txt</license>
+                    <excludes>
+                        <exclude>dependencies:commons-lang:commons-lang</exclude>
+                        <exclude>dependencies:com.google.guava:guava</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/Sample.java
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/Sample.java
@@ -1,0 +1,31 @@
+/**
+ * Some text.
+ * And other.
+ */
+package com.qulice.foo;
+
+import java.io.InputStream;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Test class.
+ * @author John Smith (John.Smith@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public final class Sample {
+    /**
+     * Utility constructor.
+     */
+    private Sample() {
+        // do nothing
+    }
+
+    /**
+     * Test method.
+     * @return Stream.
+     */
+    public static InputStream test() {
+        return IOUtils.toInputStream("oops");
+    }
+}

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/package-info.java
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/src/main/java/com/qulice/foo/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Some text.
+ * And other.
+ */
+package com.qulice.foo;

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
@@ -1,6 +1,6 @@
 /**
  *
- * Copyright (c) 2011, Qulice.com
+ * Copyright (c) 2011-2016, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
+++ b/qulice-maven-plugin/src/it/dependency-violations-exclude/verify.groovy
@@ -1,0 +1,37 @@
+/**
+ *
+ * Copyright (c) 2011, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @version $Id$
+ *
+ * Validate that the build really failed and violations were reported.
+ */
+
+def log = new File(basedir, 'build.log')
+assert log.text.contains('No dependency problems found')

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -30,6 +30,9 @@
 package com.qulice.maven;
 // @checkstyle LineLength (20 lines)
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Collections2;
 import com.jcabi.log.Logger;
 import com.qulice.spi.ValidationException;
 import java.util.Collection;
@@ -49,6 +52,7 @@ import org.codehaus.plexus.context.ContextException;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.16
  */
 final class DependenciesValidator implements MavenValidator {
 
@@ -60,13 +64,18 @@ final class DependenciesValidator implements MavenValidator {
     @Override
     public void validate(final MavenEnvironment env)
         throws ValidationException {
+        final Collection<String> excludes = env.excludes("dependencies");
         if (!env.outdir().exists()
             || "pom".equals(env.project().getPackaging())
-            || env.exclude("dependencies", "")) {
+            || excludes.contains(".*")
+            ) {
             Logger.info(this, "No dependency analysis in this project");
             return;
         }
-        final Collection<String> unused = DependenciesValidator.unused(env);
+        final Collection<String> unused = Collections2.filter(
+            DependenciesValidator.unused(env),
+            Predicates.not(new DependenciesValidator.ExcludePredicate(excludes))
+        );
         if (!unused.isEmpty()) {
             Logger.warn(
                 this,
@@ -75,7 +84,10 @@ final class DependenciesValidator implements MavenValidator {
                 StringUtils.join(unused, DependenciesValidator.SEP)
             );
         }
-        final Collection<String> used = DependenciesValidator.used(env);
+        final Collection<String> used = Collections2.filter(
+            DependenciesValidator.used(env),
+            Predicates.not(new DependenciesValidator.ExcludePredicate(excludes))
+        );
         if (!used.isEmpty()) {
             Logger.warn(
                 this,
@@ -84,7 +96,7 @@ final class DependenciesValidator implements MavenValidator {
                 StringUtils.join(used, DependenciesValidator.SEP)
             );
         }
-        final Integer failures = used.size() + unused.size();
+        final int failures = used.size() + unused.size();
         if (failures > 0) {
             throw new ValidationException(
                 "%d dependency problem(s) found",
@@ -150,4 +162,34 @@ final class DependenciesValidator implements MavenValidator {
         return unused;
     }
 
+    /**
+     * Predicate for excluded dependencies.
+     */
+    private static class ExcludePredicate implements Predicate<String> {
+
+        /**
+         * List of excludes.
+         */
+        private final transient Collection<String> excludes;
+
+        /**
+         * Constructor.
+         * @param excludes List of excludes.
+         */
+        ExcludePredicate(final Collection<String> excludes) {
+            this.excludes = excludes;
+        }
+
+        @Override
+        public boolean apply(final String name) {
+            boolean ignore = false;
+            for (final String exclude : this.excludes) {
+                if (name.startsWith(exclude)) {
+                    ignore = true;
+                    break;
+                }
+            }
+            return ignore;
+        }
+    }
 }

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -28,7 +28,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.qulice.maven;
-// @checkstyle LineLength (20 lines)
 
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;

--- a/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
+++ b/qulice-maven-plugin/src/site/apt/example-exclude.apt.vm
@@ -86,3 +86,10 @@ Exclude
   2) <<<findbugs:com.qulice.foo.Bar>>> excludes only class Bar in appropriate
   packages.
   See http://findbugs.sourceforge.net/manual/filter.html
+
+  Dependencies exclude uses syntax of groupId:artifactId, so to exclude e.g.
+  guava library you should add <<<dependencies:com.google.guava:guava>>> as an
+  exclude. Multiple exclude tags can be provided to exclude multiple
+  dependencies. To exclude all dependency checks <<<dependencies:.*>>> should
+  be used.
+


### PR DESCRIPTION
#398 
* added exclude support for dependency validation (using `dependencies:groupId:artifactId`)
* excluding all dependencies will now need `dependencies:.*`