### PR TITLE
Checkstyles ignores long lines if they have a URL #625

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -344,7 +344,7 @@
         </module>
         <module name="LineLength">
             <property name="max" value="80"/>
-            <property name="ignorePattern" value="^import .*$"/>
+            <property name="ignorePattern" value="^import .*$|https?://[\w\d-]+\.[\w\d]+"/>
         </module>
         <module name="AnonInnerLength" />
         <module name="MethodLength"/>

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -344,7 +344,7 @@
         </module>
         <module name="LineLength">
             <property name="max" value="80"/>
-            <property name="ignorePattern" value="^import .*$|https?:\/\/.+"/>
+            <property name="ignorePattern" value="^import .*$|^\s+\*.*https?:\/\/.+"/>
         </module>
         <module name="AnonInnerLength" />
         <module name="MethodLength"/>

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -344,7 +344,7 @@
         </module>
         <module name="LineLength">
             <property name="max" value="80"/>
-            <property name="ignorePattern" value="^import .*$|^\s+\*.*https?:\/\/.+"/>
+            <property name="ignorePattern" value="^import .*$|^\s+\*\s.*https?:\/\/.+"/>
         </module>
         <module name="AnonInnerLength" />
         <module name="MethodLength"/>

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -344,7 +344,7 @@
         </module>
         <module name="LineLength">
             <property name="max" value="80"/>
-            <property name="ignorePattern" value="^import .*$|https?://[\w\d-]+\.[\w\d]+"/>
+            <property name="ignorePattern" value="^import .*$|https?:\/\/.+"/>
         </module>
         <module name="AnonInnerLength" />
         <module name="MethodLength"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -458,6 +458,18 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * Test if URLs are valid despite having a line length over 80.
+     * @throws Exception In case of error
+     */
+    @Test
+    public void doesNotRejectUrlsInLongLines() throws Exception {
+        this.validateCheckstyle(
+            "UrlInLongLine.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
      * Convert file name to URL.
      * @param file The file
      * @return The URL

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/UrlInLongLine.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/UrlInLongLine.java
@@ -1,0 +1,14 @@
+/**
+ * Hello.
+ */
+package foo.bar;
+
+/**
+ * Very long lines.
+ * https://very-long.net/thisUrlIsVeryLong?AndItHasQueryParams=1&url%2encoding#withHashTags
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public interface UrlInLongLine {
+}


### PR DESCRIPTION
Simply added a new regex pattern to the "ignorePattern" property in checkstyles lineLength module.

Ticket for this PR: #625 