### PR TITLE
#623 Methods that throw exceptions are valid non-static methods

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -103,7 +103,8 @@ public final class NonStaticMethodCheck extends Check {
         }
         if (!AnnotationUtility.containsAnnotation(method, "Override")
             && !isInAbstractOrNativeMethod(method)
-            && !method.branchContains(TokenTypes.LITERAL_THIS)) {
+            && !method.branchContains(TokenTypes.LITERAL_THIS)
+            && !method.branchContains(TokenTypes.LITERAL_THROW)) {
             final int line = method.getLineNo();
             this.log(
                 line,

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
@@ -35,9 +35,8 @@ public class Bar {
     // this method is not static, but it is native
     public native void someNativeMethod();
 
-
-    // this method is not yet implemented
     public void someUnimplementedMethod() {
+        // this method is not yet implemented
         throw new UnsupportedOperationException();
     }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
@@ -34,4 +34,10 @@ public class Bar {
 
     // this method is not static, but it is native
     public native void someNativeMethod();
+
+
+    // this method is not yet implemented
+    public void someUnimplementedMethod() {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
#623 Methods that throw exceptions are valid non-static methods. Updated the check and verified it with a change to the test.