### PR TITLE
Ignore lines between anon inner classes #653

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
@@ -64,7 +64,9 @@ public final class EmptyLinesCheck extends Check {
     @Override
     public void visitToken(final DetailAST ast) {
         final DetailAST opening = ast.findFirstToken(TokenTypes.SLIST);
-        if (opening != null) {
+        final String text = ast.getParent().getPreviousSibling().getText();
+        if (opening != null
+            && !"AnonymousInnerClass".equals(text)) {
             final DetailAST closing =
                 opening.findFirstToken(TokenTypes.RCURLY);
             final int first = opening.getLineNo();

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -470,6 +470,18 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * Test if spaces are permitted between anonymous inner classes's methods.
+     * @throws Exception In case of error
+     */
+    @Test
+    public void doesNotRejectSpaceBetweenAnonInnerClasses() throws Exception {
+        this.validateCheckstyle(
+            "AnonymousInnerClass.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
      * Convert file name to URL.
      * @param file The file
      * @return The URL

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/AnonymousInnerClass.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/AnonymousInnerClass.java
@@ -1,0 +1,37 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public final class AnonymousInnerClass {
+    /**
+     * Method with space inbetween anonymous innter class methods.
+     */
+    public void methodwithAnonymousInnerClass() {
+        final Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                this.doSomething();
+            }
+
+            private void doSomething() {
+            }
+        };
+
+        new Runnable() {
+            @Override
+            public void run() {
+                this.doSomething();
+            }
+
+            private void doSomething() {
+            }
+        }.run();
+    }
+}


### PR DESCRIPTION
For issue #653 

It is simply ignoring scanning down anonymous inner class structures. This does NOT ignore methods inside of anonymous inner classes, as the call to `visitToken` will trigger for EACH method inside of the anonymous inner type. Therefore empty lines inside of any method will still trigger an error. All unit tests work, including the previous unit tests inside `CheckTests.java`.