### PR TITLE
squid:S2065 - Fields in non-serializable classes should not be "transient"

### DIFF
--- a/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
@@ -184,7 +184,7 @@ public final class AntEnvironment implements Environment {
         /**
          * URLs for class loading.
          */
-        private final transient List<URL> urls;
+        private final List<URL> urls;
 
         /**
          * Constructor.

--- a/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
@@ -57,17 +57,17 @@ public final class QuliceTask extends Task {
     /**
      * Sources dirs.
      */
-    private transient Path sources;
+    private Path sources;
 
     /**
      * Classes dir (only one dir is supported).
      */
-    private transient File classes;
+    private File classes;
 
     /**
      * Classpath dirs and files.
      */
-    private transient Path classpath;
+    private Path classpath;
 
     /**
      * Set source dirs.

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -49,12 +49,12 @@ final class CheckstyleListener implements AuditListener {
     /**
      * Environment.
      */
-    private final transient Environment env;
+    private final Environment env;
 
     /**
      * Collection of events collected.
      */
-    private final transient List<AuditEvent> all;
+    private final List<AuditEvent> all;
 
     /**
      * Public ctor.

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
@@ -44,7 +44,7 @@ public final class ConditionalRegexpMultilineCheck extends
     /**
      * Condition that has to pass.
      */
-    private transient Pattern condition = Pattern.compile(".");
+    private Pattern condition = Pattern.compile(".");
 
     @Override
     public void processFiltered(final File file, final List<String> lines) {

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -69,7 +69,7 @@ public final class JavadocTagsCheck extends Check {
     /**
      * Map of tag and its pattern.
      */
-    private final transient Map<String, Pattern> tags =
+    private final Map<String, Pattern> tags =
         new HashMap<String, Pattern>();
 
     @Override

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -61,7 +61,7 @@ public final class NonStaticMethodCheck extends Check {
      * Files to exclude from this check.
      * This is mostly to exclude JUnit tests.
      */
-    private transient Pattern exclude = Pattern.compile("^$");
+    private Pattern exclude = Pattern.compile("^$");
 
     /**
      * Exclude files matching given pattern.

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -55,32 +55,32 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
     /**
      * Environment to pass to validators.
      */
-    private final transient DefaultMavenEnvironment environment =
+    private final DefaultMavenEnvironment environment =
         new DefaultMavenEnvironment();
 
     /**
      * Maven project, to be injected by Maven itself.
      */
     @Component
-    private transient MavenProject project;
+    private MavenProject project;
 
     /**
      * Maven session, to be injected by Maven itself.
      */
     @Component
-    private transient MavenSession session;
+    private MavenSession session;
 
     /**
      * Maven plugin manager, to be injected by Maven itself.
      */
     @Component
-    private transient MavenPluginManager manager;
+    private MavenPluginManager manager;
 
     /**
      * Shall we skip execution?
      */
     @Parameter(property = "qulice.skip", defaultValue = "false")
-    private transient boolean skip;
+    private boolean skip;
 
     /**
      * Location of License file. If it is an absolute file name you should
@@ -89,14 +89,14 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
      * @since 0.1
      */
     @Parameter(property = "qulice.license", defaultValue = "LICENSE.txt")
-    private transient String license = "LICENSE.txt";
+    private String license = "LICENSE.txt";
 
     /**
      * List of regular expressions to exclude.
      * @since 0.4
      */
     @Parameter(property = "qulice.excludes")
-    private final transient Collection<String> excludes =
+    private final Collection<String> excludes =
         new LinkedList<String>();
 
     /**
@@ -108,7 +108,7 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
         property = "qulice.asserts",
         required = false
     )
-    private final transient Collection<String> asserts =
+    private final Collection<String> asserts =
         new LinkedList<String>();
 
     /**

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -302,7 +302,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         /**
          * URLs for class loading.
          */
-        private final transient List<URL> urls;
+        private final List<URL> urls;
 
         /**
          * Constructor.
@@ -328,7 +328,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         /**
          * Path to match.
          */
-        private final transient String name;
+        private final String name;
 
         /**
          * Constructor.
@@ -355,7 +355,7 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
         /**
          * Name of checker.
          */
-        private final transient String checker;
+        private final String checker;
 
         /**
          * Constructor.

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -169,7 +169,7 @@ final class DependenciesValidator implements MavenValidator {
         /**
          * List of excludes.
          */
-        private final transient Collection<String> excludes;
+        private final Collection<String> excludes;
 
         /**
          * Constructor.

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -65,17 +65,17 @@ public final class MojoExecutor {
     /**
      * Plugin manager.
      */
-    private final transient MavenPluginManager manager;
+    private final MavenPluginManager manager;
 
     /**
      * Maven session.
      */
-    private final transient MavenSession session;
+    private final MavenSession session;
 
     /**
      * Helper for plugin manager.
      */
-    private final transient DefaultMavenPluginManagerHelper helper;
+    private final DefaultMavenPluginManagerHelper helper;
 
     /**
      * Public ctor.

--- a/qulice-pmd/src/main/java/com/qulice/pmd/DataSourceReader.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/DataSourceReader.java
@@ -49,7 +49,7 @@ public final class DataSourceReader {
     /**
      * Data source.
      */
-    private final transient DataSource source;
+    private final DataSource source;
 
     /**
      * Creates new instance of <code>DataSourceReader</code> with the specified

--- a/qulice-pmd/src/main/java/com/qulice/pmd/Files.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/Files.java
@@ -48,7 +48,7 @@ public final class Files {
     /**
      * The environment.
      */
-    private final transient Environment environment;
+    private final Environment environment;
 
     /**
      * Constructor.

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
@@ -50,12 +50,12 @@ final class PmdListener implements ReportListener {
     /**
      * Environment.
      */
-    private final transient Environment env;
+    private final Environment env;
 
     /**
      * Violations.
      */
-    private final transient Collection<RuleViolation> violations;
+    private final Collection<RuleViolation> violations;
 
     /**
      * Public ctor.

--- a/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -55,17 +55,17 @@ public final class SourceValidator {
     /**
      * Rule context.
      */
-    private final transient RuleContext context;
+    private final RuleContext context;
 
     /**
      * Report listener.
      */
-    private final transient PmdListener listener;
+    private final PmdListener listener;
 
     /**
      * Rules.
      */
-    private final transient PMDConfiguration config;
+    private final PMDConfiguration config;
 
     /**
      * Creates new instance of <code>SourceValidator</code>.

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -129,19 +129,19 @@ public interface Environment {
         /**
          * The basedir.
          */
-        private final transient File basedir;
+        private final File basedir;
         /**
          * Files for classpath.
          */
-        private final transient Set<String> classpath;
+        private final Set<String> classpath;
         /**
          * Map of params.
          */
-        private final transient Map<String, String> params;
+        private final Map<String, String> params;
         /**
          * Exclude patterns.
          */
-        private transient String excl;
+        private String excl;
 
         /**
          * Public ctor.

--- a/qulice-xml/src/main/java/com/qulice/xml/Prettifier.java
+++ b/qulice-xml/src/main/java/com/qulice/xml/Prettifier.java
@@ -49,7 +49,7 @@ public final class Prettifier {
     /**
      * Input XML.
      */
-    private final transient String xml;
+    private final String xml;
 
     /**
      * Constructor.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2065 - Fields in non-serializable classes should not be "transient".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2065
Please let me know if you have any questions.
George Kankava