### PR TITLE
#144 throws should be real

### DIFF
--- a/qulice-findbugs/pom.xml
+++ b/qulice-findbugs/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -130,6 +129,11 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>bcel-findbugs</artifactId>
             <version>6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mebigfatguy.fb-contrib</groupId>
+            <artifactId>fb-contrib</artifactId>
+            <version>6.6.0</version>
         </dependency>
         <dependency>
             <!-- Required for FindBugs -->

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
@@ -29,8 +29,10 @@
  */
 package com.qulice.findbugs;
 
+import com.google.common.collect.Iterables;
 import com.jcabi.log.Logger;
 import com.jcabi.log.VerboseProcess;
+import com.mebigfatguy.fbcontrib.FBContrib;
 import com.qulice.spi.Environment;
 import com.qulice.spi.ValidationException;
 import com.qulice.spi.Validator;
@@ -64,6 +66,7 @@ import org.xembly.Xembler;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  */
+@SuppressWarnings("PMD.ExcessiveImports")
 public final class FindBugsValidator implements Validator {
 
     /**
@@ -103,15 +106,16 @@ public final class FindBugsValidator implements Validator {
         args.add(env.basedir().getPath());
         args.add(env.outdir().getPath());
         // @checkstyle MultipleStringLiteralsCheck (2 lines)
-        args.add(StringUtils.join(env.classpath(), ",")
-            .replace("\\", "/")
+        args.add(
+            StringUtils.join(env.classpath(), ",").replace("\\", "/")
         );
         final Iterable<String> excludes = env.excludes("findbugs");
+        args.add(this.jar(FBContrib.class).toString());
         if (excludes.iterator().hasNext()) {
             args.add(FindBugsValidator.excludes(env, excludes));
         }
         return new VerboseProcess(
-            new ProcessBuilder(args), Level.ALL, Level.ALL
+            new ProcessBuilder(args), Level.INFO, Level.INFO
         ).stdout();
     }
 
@@ -134,7 +138,9 @@ public final class FindBugsValidator implements Validator {
                     this.jar(ClassVisitor.class),
                     this.jar(When.class),
                     this.jar(FormatterNumberFormatException.class),
-                    this.jar(StringEscapeUtils.class)
+                    this.jar(StringEscapeUtils.class),
+                    this.jar(FBContrib.class),
+                    this.jar(Iterables.class)
                 ),
                 // @checkstyle MultipleStringLiteralsCheck (1 line)
                 System.getProperty("path.separator")

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
@@ -29,15 +29,25 @@
  */
 package com.qulice.findbugs;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Collections2;
+import com.jcabi.aspects.Tv;
+import com.mebigfatguy.fbcontrib.utils.BugType;
+import edu.umd.cs.findbugs.BugInstance;
 import edu.umd.cs.findbugs.BugReporter;
 import edu.umd.cs.findbugs.Detector;
 import edu.umd.cs.findbugs.DetectorFactoryCollection;
 import edu.umd.cs.findbugs.FindBugs2;
+import edu.umd.cs.findbugs.Plugin;
+import edu.umd.cs.findbugs.PluginException;
 import edu.umd.cs.findbugs.PrintingBugReporter;
 import edu.umd.cs.findbugs.Project;
 import edu.umd.cs.findbugs.config.UserPreferences;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
 
 /**
  * Executed by {@link FindBugsValidator}, but in a new process.
@@ -67,9 +77,45 @@ public final class Wrap {
      * @param args Arguments
      */
     public static void run(final String... args) {
+        final Project project =
+            Wrap.project(args[0], args[1], args[2].split(","));
+        try {
+            Plugin.loadCustomPlugin(new File(args[Tv.THREE]), project);
+        } catch (final PluginException ex) {
+            throw new IllegalStateException(ex);
+        }
         final FindBugs2 findbugs = new FindBugs2();
-        findbugs.setProject(Wrap.project(args[0], args[1], args[2].split(",")));
-        final BugReporter reporter = new PrintingBugReporter();
+        findbugs.setProject(project);
+        final Collection<String> ignored = Collections2.filter(
+            Collections2.transform(
+                Arrays.asList(BugType.values()),
+                new Function<BugType, String>() {
+                    @Override
+                    public String apply(final BugType bug) {
+                        final String name;
+                        if (bug == null) {
+                            name = "Missing";
+                        } else {
+                            name = bug.name();
+                        }
+                        return name;
+                    }
+                }
+            ),
+            Predicates.not(
+                Predicates.equalTo(
+                    BugType.BED_BOGUS_EXCEPTION_DECLARATION.name()
+                )
+            )
+        );
+        final BugReporter reporter = new PrintingBugReporter() {
+            @Override
+            protected void doReportBug(final BugInstance bug) {
+                if (!ignored.contains(bug.getType())) {
+                    super.doReportBug(bug);
+                }
+            }
+        };
         reporter.getProjectStats().getProfiler().start(findbugs.getClass());
         reporter.setPriorityThreshold(Detector.LOW_PRIORITY);
         findbugs.setBugReporter(reporter);
@@ -82,9 +128,8 @@ public final class Wrap {
         findbugs.setNoClassOk(true);
         findbugs.setScanNestedArchives(true);
         try {
-            // @checkstyle MagicNumberCheck (2 lines)
-            if (args.length > 3) {
-                findbugs.addFilter(args[3], false);
+            if (args.length > Tv.FOUR) {
+                findbugs.addFilter(args[Tv.FOUR], false);
             }
             findbugs.execute();
         } catch (final IOException ex) {

--- a/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
+++ b/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
@@ -35,7 +35,7 @@ import com.qulice.spi.ValidationException;
 import org.junit.Test;
 
 /**
- * Test case for {@link FindbugsValidator}.
+ * Test case for {@link FindBugsValidator}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @checkstyle MultipleStringLiteralsCheck (200 lines)
@@ -67,6 +67,30 @@ public final class FindBugsValidatorTest {
                     "final class Main {",
                     "public void foo() throws InterruptedException {",
                     "System.out.println(\"test\");",
+                    "}",
+                    "}"
+                )
+            )
+            .mock();
+        final Environment env = new Environment.Mock()
+            .withFile("target/classes/Main.class", bytecode)
+            .withDefaultClasspath();
+        new FindBugsValidator().validate(env);
+    }
+
+    /**
+     * FindbugsValidator can ignore correct throws.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void ignoresCorrectlyAddedThrows() throws Exception {
+        final byte[] bytecode = new BytecodeMocker()
+            .withSource(
+                Joiner.on("\n").join(
+                    "package test;",
+                    "final class Main {",
+                    "public void foo() throws InterruptedException {",
+                    "Thread.sleep(1);",
                     "}",
                     "}"
                 )


### PR DESCRIPTION
#144 
* using fb-contrib rule `BED_BOGUS_EXCEPTION_DECLARATION` to check for throws declaration with reality
* one drawback is that this check ignores public methods - this is sometimes required for APIs (see mebigfatguy/fb-contrib#92), but the good news is that it works for final methods/classes so it should cover almost all classes (as qulice enforces them to be final if they are not abstract)