### PR TITLE
#648 upgrade to qulice 0.15.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
                         <plugin>
                             <groupId>com.qulice</groupId>
                             <artifactId>qulice-maven-plugin</artifactId>
-                            <version>0.15.2</version>
+                            <version>0.15.4</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/AntEnvironment.java
@@ -53,6 +53,7 @@ import org.apache.tools.ant.types.Path;
  * Environment, passed from ant task to validators.
  * @author Yuriy Alevohin (alevohin@mail.ru)
  * @version $Id$
+ * @since 0.13
  */
 public final class AntEnvironment implements Environment {
 

--- a/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/QuliceTask.java
@@ -51,6 +51,7 @@ import org.apache.tools.ant.types.Path;
  * @checkstyle ClassDataAbstractionCouplingCheck (170 lines)
  * @author Yuriy Alevohin (alevohin@mail.ru)
  * @version $Id$
+ * @since 0.13
  */
 public final class QuliceTask extends Task {
 

--- a/qulice-ant/src/main/java/com/qulice/ant/package-info.java
+++ b/qulice-ant/src/main/java/com/qulice/ant/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yuriy Alevohin (alevohin@mail.ru)
  * @version $Id$
+ * @since 0.13
  */
 package com.qulice.ant;

--- a/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/AntEnvironmentTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
  *
  * @author Yuriy Alevohin (alevohin@mail.ru)
  * @version $Id$
+ * @since 0.13
  * @todo #337 Implement unit tests at AntEnvironmentTest
  */
 public class AntEnvironmentTest {

--- a/qulice-ant/src/test/java/com/qulice/ant/package-info.java
+++ b/qulice-ant/src/test/java/com/qulice/ant/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yuriy Alevohin (alevohin@mail.ru)
  * @version $Id$
+ * @since 0.13
  */
 package com.qulice.ant;

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/BracketsStructureCheck.java
@@ -59,6 +59,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class BracketsStructureCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CascadeIndentationCheck.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @author Hamdi Douss (douss.hamdi@gmail.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class CascadeIndentationCheck extends AbstractFileSetCheck {
     /**
@@ -58,11 +59,12 @@ public final class CascadeIndentationCheck extends AbstractFileSetCheck {
             final String line = lines.get(pos);
             final int current = CascadeIndentationCheck.indentation(line);
             if (CascadeIndentationCheck.inCommentBlock(line)
-                || line.length() == 0) {
+                || line.isEmpty()) {
                 continue;
             }
             if (current > previous
-                && current != previous + LINE_INDENT_DIFF) {
+                && current != previous
+                + CascadeIndentationCheck.LINE_INDENT_DIFF) {
                 this.log(
                     pos + 1,
                     String.format(

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleListener.java
@@ -42,6 +42,7 @@ import java.util.List;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @checkstyle ClassDataAbstractionCoupling (260 lines)
  */
 final class CheckstyleListener implements AuditListener {

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -57,6 +57,7 @@ import org.xml.sax.InputSource;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @checkstyle ClassDataAbstractionCoupling (260 lines)
  */
 public final class CheckstyleValidator implements Validator {

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConditionalRegexpMultilineCheck.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
  * Performs multiline regexp match only if a regexp condition passes.
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
+ * @since 0.5
  */
 public final class ConditionalRegexpMultilineCheck extends
     RegexpMultilineCheck {

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ConstantUsageCheck.java
@@ -39,6 +39,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class ConstantUsageCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CurlyBracketsStructureCheck.java
@@ -59,6 +59,7 @@ import java.util.List;
  *
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.6
  */
 public final class CurlyBracketsStructureCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/EmptyLinesCheck.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @author Jimmy Spivey (JimDeanSpivey@gmail.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class EmptyLinesCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/FinalSemicolonInTryWithResourcesCheck.java
@@ -38,6 +38,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @author Hamdi Douss (douss.hamdi@gmail.com)
  * @version $Id$
+ * @since 0.15
  */
 public final class FinalSemicolonInTryWithResourcesCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ImportCohesionCheck.java
@@ -43,6 +43,7 @@ import java.util.List;
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.CyclomaticComplexity")
 public final class ImportCohesionCheck extends AbstractFileSetCheck {

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocLocationCheck.java
@@ -43,6 +43,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class JavadocLocationCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -61,6 +61,7 @@ import java.util.regex.Pattern;
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @checkstyle LineLength (1 line)
  * @see <a href="http://svnbook.red-bean.com/en/1.4/svn.advanced.props.special.keywords.html">Keywords substitution in Subversion</a>
  */

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRange.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRange.java
@@ -36,6 +36,7 @@ package com.qulice.checkstyle;
  *
  * @author Jimmy Spivey (JimDeanSpivey@gmail.com)
  * @version $Id$
+ * @since 0.16
  */
 public final class LineRange {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRanges.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/LineRanges.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
  *
  * @author Jimmy Spivey (JimDeanSpivey@gmail.com)
  * @version $Id$
+ * @since 0.16
  */
 public final class LineRanges {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodBodyCommentsCheck.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @todo #260 Add handling of multiple anonymous classes inside methods by
  *  looking at the recursive tree.
  */

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MethodsOrderCheck.java
@@ -44,6 +44,7 @@ import java.util.Map;
  * Right order is: public, protected and private
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.6
  */
 public final class MethodsOrderCheck extends Check {
 
@@ -184,12 +185,13 @@ public final class MethodsOrderCheck extends Check {
         private static Map<Integer, MethodsOrderCheck.Modifiers> mdos;
 
         static {
-            mdos = ImmutableMap.<Integer, Modifiers>builder()
-                .put(PUB.getType(), PUB)
-                .put(PROT.getType(), PROT)
-                .put(-1, DEF)
-                .put(PRIV.getType(), PRIV)
-                .build();
+            MethodsOrderCheck.Modifiers.mdos =
+                ImmutableMap.<Integer, MethodsOrderCheck.Modifiers>builder()
+                    .put(PUB.getType(), PUB)
+                    .put(PROT.getType(), PROT)
+                    .put(-1, DEF)
+                    .put(PRIV.getType(), PRIV)
+                    .build();
         }
 
         /**

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/MultilineJavadocTagsCheck.java
@@ -58,6 +58,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
  *
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class MultilineJavadocTagsCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NoJavadocForOverriddenMethodsCheck.java
@@ -44,7 +44,7 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtility;
  *
  * @author Hamdi Douss (douss.hamdi@gmail.com)
  * @version $Id$
- * @since 0.15.5
+ * @since 0.16
  */
 public final class NoJavadocForOverriddenMethodsCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -54,6 +54,7 @@ import java.util.regex.Pattern;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.3
  */
 public final class NonStaticMethodCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
@@ -42,6 +42,7 @@ import java.util.List;
  *
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.6
  */
 public final class ProtectedMethodInFinalClassCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/StringLiteralsConcatenationCheck.java
@@ -59,6 +59,7 @@ import java.util.List;
  * @author Dzmitry Petrushenka (dpetruha@gmail.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class StringLiteralsConcatenationCheck extends Check {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/package-info.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.checkstyle;

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -56,6 +56,7 @@ import org.xml.sax.InputSource;
  * Integration test case for all checkstyle checks.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @RunWith(Parameterized.class)
 public final class ChecksTest {

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
  * Test case for {@link CheckstyleValidator} class.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @checkstyle MultipleStringLiterals (300 lines)
  * @todo #412:30min Split this class into smaller ones and remove PMD
  *  exclude `TooManyMethods`. Good candidates for moving out of this class

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -42,6 +42,7 @@ import org.junit.runners.model.Statement;
  * Builder of {@code LICENSE.txt} content.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.4
  */
 public final class LicenseRule implements TestRule {
 

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/package-info.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.checkstyle;

--- a/qulice-codenarc/src/main/java/com/qulice/codenarc/CodeNarcValidator.java
+++ b/qulice-codenarc/src/main/java/com/qulice/codenarc/CodeNarcValidator.java
@@ -46,6 +46,7 @@ import org.codenarc.rule.Violation;
  *
  * @author Pavlo Shamrai (pshamrai@gmail.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class CodeNarcValidator implements Validator {
 

--- a/qulice-codenarc/src/main/java/com/qulice/codenarc/package-info.java
+++ b/qulice-codenarc/src/main/java/com/qulice/codenarc/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Pavlo Shamrai (pshamrai@gmail.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.codenarc;

--- a/qulice-codenarc/src/test/java/com/qulice/codenarc/CodeNarcValidatorTest.java
+++ b/qulice-codenarc/src/test/java/com/qulice/codenarc/CodeNarcValidatorTest.java
@@ -49,6 +49,7 @@ import org.junit.Test;
  * @author Pavlo Shamrai (pshamrai@gmail.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.TestClassWithoutTestCases")
 public final class CodeNarcValidatorTest {

--- a/qulice-codenarc/src/test/java/com/qulice/codenarc/package-info.java
+++ b/qulice-codenarc/src/test/java/com/qulice/codenarc/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Pavlo Shamrai (pshamrai@gmail.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.codenarc;

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
@@ -63,6 +63,7 @@ import org.xembly.Xembler;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class FindBugsValidator implements Validator {
 

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/Wrap.java
@@ -44,6 +44,7 @@ import java.io.IOException;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class Wrap {
 

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.findbugs;

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
@@ -41,6 +41,7 @@ import org.apache.commons.io.IOUtils;
  * Mocks bytecode.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class BytecodeMocker {
 

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.findbugs;

--- a/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
+++ b/qulice-findbugs/src/test/java/com/qulice/findbugs/FindBugsValidatorTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
  * Test case for {@link FindbugsValidator}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @checkstyle MultipleStringLiteralsCheck (200 lines)
  */
 public final class FindBugsValidatorTest {

--- a/qulice-findbugs/src/test/java/com/qulice/findbugs/package-info.java
+++ b/qulice-findbugs/src/test/java/com/qulice/findbugs/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.findbugs;

--- a/qulice-gradle-plugin/src/main/java/com/qulice/gradle/QulicePlugin.java
+++ b/qulice-gradle-plugin/src/main/java/com/qulice/gradle/QulicePlugin.java
@@ -36,7 +36,7 @@ import org.gradle.api.Project;
  * Main class of the Qulice Gradle plugin.
  * @author Dmitri Pisarenko (dp@altruix.co)
  * @version $Id$
- * @since 1.0
+ * @since 0.13
  */
 public final class QulicePlugin implements Plugin<Project> {
     /**

--- a/qulice-gradle-plugin/src/main/java/com/qulice/gradle/package-info.java
+++ b/qulice-gradle-plugin/src/main/java/com/qulice/gradle/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Dmitri Pisarenko (dp@altruix.co)
  * @version $Id$
+ * @since 0.13
  */
 package com.qulice.gradle;

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/AbstractQuliceMojo.java
@@ -48,6 +48,7 @@ import org.slf4j.impl.StaticLoggerBinder;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public abstract class AbstractQuliceMojo extends AbstractMojo
     implements Contextualizable {
@@ -86,14 +87,12 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
      * Location of License file. If it is an absolute file name you should
      * prepend it with "file:" prefix. Otherwise it is treated like a resource
      * name and will be found in classpath (if available).
-     * @since 0.1
      */
     @Parameter(property = "qulice.license", defaultValue = "LICENSE.txt")
     private transient String license = "LICENSE.txt";
 
     /**
      * List of regular expressions to exclude.
-     * @since 0.4
      */
     @Parameter(property = "qulice.excludes")
     private final transient Collection<String> excludes =
@@ -101,7 +100,6 @@ public abstract class AbstractQuliceMojo extends AbstractMojo
 
     /**
      * List of xpath queries to validate pom.xml.
-     * @since 0.5
      * @checkstyle IndentationCheck (5 lines)
      */
     @Parameter(

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/CheckMojo.java
@@ -42,6 +42,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY,
     requiresDependencyResolution = ResolutionScope.TEST)

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/CoberturaValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/CoberturaValidator.java
@@ -37,6 +37,7 @@ import java.util.Properties;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class CoberturaValidator implements MavenValidator {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -62,6 +62,7 @@ import org.codehaus.plexus.context.Context;
  * @checkstyle ClassDataAbstractionCouplingCheck (300 lines)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class DefaultMavenEnvironment implements MavenEnvironment {

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultValidatorsProvider.java
@@ -38,6 +38,7 @@ import java.util.Set;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @checkstyle ClassDataAbstractionCoupling (500 lines)
  */
 final class DefaultValidatorsProvider implements ValidatorsProvider {

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DependenciesValidator.java
@@ -51,7 +51,7 @@ import org.codehaus.plexus.context.ContextException;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
- * @since 0.16
+ * @since 0.3
  */
 final class DependenciesValidator implements MavenValidator {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/EnforcerValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/EnforcerValidator.java
@@ -37,6 +37,7 @@ import java.util.Properties;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class EnforcerValidator implements MavenValidator {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/InstrumentMojo.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/InstrumentMojo.java
@@ -40,6 +40,7 @@ import org.apache.maven.plugins.annotations.Mojo;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @Mojo(name = "instrument", defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public final class InstrumentMojo extends AbstractQuliceMojo {

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/JslintValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/JslintValidator.java
@@ -37,6 +37,7 @@ import java.util.Properties;
  *
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.7
  */
 public final class JslintValidator implements MavenValidator {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenEnvironment.java
@@ -41,6 +41,7 @@ import org.codehaus.plexus.context.Context;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.TooManyMethods")
 interface MavenEnvironment extends Environment {

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MavenValidator.java
@@ -36,6 +36,7 @@ import com.qulice.spi.ValidationException;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 interface MavenValidator {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/MojoExecutor.java
@@ -59,6 +59,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class MojoExecutor {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -50,6 +50,7 @@ import org.apache.commons.io.FileUtils;
  *
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.6
  */
 public final class PomXpathValidator implements MavenValidator {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SnapshotsValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SnapshotsValidator.java
@@ -41,6 +41,7 @@ import org.apache.maven.model.Plugin;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class SnapshotsValidator implements MavenValidator {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
@@ -52,6 +52,7 @@ import org.apache.maven.project.MavenProject;
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  * @checkstyle LineLength (1 line)
  * @see <a href="http://svnbook.red-bean.com/en/1.5/svn.ref.properties.html">Properties in Subversion</a>
  */

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/ValidatorsProvider.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/ValidatorsProvider.java
@@ -37,6 +37,7 @@ import java.util.Set;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 interface ValidatorsProvider {
 

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/package-info.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.maven;

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
  * Test case for {@link CheckMojo} class.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class CheckMojoTest {
 

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -41,6 +41,7 @@ import org.mockito.Mockito;
  * Test case for {@link DefaultMavenEnvironment} class.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.8
  * @checkstyle MultipleStringLiterals (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultValidatorsProviderTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
  * Test case for {@link ValidatorsProvider} class.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class DefaultValidatorsProviderTest {
 

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
  * Test case for {@link DependenciesValidator} class.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class DependenciesValidatorTest {
 

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenEnvironmentMocker.java
@@ -45,6 +45,7 @@ import org.slf4j.impl.StaticLoggerBinder;
  * Mocker of {@link MavenProject}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.4
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class MavenEnvironmentMocker {

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenProjectMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/MavenProjectMocker.java
@@ -39,6 +39,7 @@ import org.mockito.Mockito;
  * Mocker of {@link MavenProject}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.4
  */
 public final class MavenProjectMocker {
 

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
  * Test case for {@link PomXpathValidator} class.
  * @author Paul Polishchuk (ppol@ua.fm)
  * @version $Id$
+ * @since 0.6
  */
 public final class PomXpathValidatorTest {
 

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/SvnPropertiesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/SvnPropertiesValidatorTest.java
@@ -35,6 +35,7 @@ import org.junit.Test;
  * Test case for {@link SvnPropertiesValidator}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class SvnPropertiesValidatorTest {
 

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/ValidatorsProviderMocker.java
@@ -38,6 +38,7 @@ import org.mockito.Mockito;
  * Mocker of ValidatorsProvider.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.4
  */
 final class ValidatorsProviderMocker {
 

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/package-info.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.maven;

--- a/qulice-pmd/src/main/java/com/qulice/pmd/DataSourceReader.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/DataSourceReader.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang3.CharEncoding;
  *
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class DataSourceReader {
 

--- a/qulice-pmd/src/main/java/com/qulice/pmd/Files.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/Files.java
@@ -41,6 +41,7 @@ import net.sourceforge.pmd.util.datasource.FileDataSource;
  *
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
 public final class Files {

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PMDValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PMDValidator.java
@@ -43,6 +43,7 @@ import net.sourceforge.pmd.util.datasource.DataSource;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class PMDValidator implements Validator {
 

--- a/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/PmdListener.java
@@ -44,6 +44,7 @@ import net.sourceforge.pmd.stat.Metric;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @version $Id$
+ * @since 0.3
  */
 final class PmdListener implements ReportListener {
 

--- a/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/SourceValidator.java
@@ -49,6 +49,7 @@ import net.sourceforge.pmd.util.datasource.DataSource;
  *
  * @author Dmitry Bashkin (dmitry.bashkin@qulice.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class SourceValidator {
 

--- a/qulice-pmd/src/main/java/com/qulice/pmd/package-info.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.pmd;

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/UnnecessaryLocalRule.java
@@ -45,6 +45,7 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
  *
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
+ * @since 0.4
  */
 public final class UnnecessaryLocalRule extends AbstractJavaRule {
     @Override

--- a/qulice-pmd/src/main/java/com/qulice/pmd/rules/package-info.java
+++ b/qulice-pmd/src/main/java/com/qulice/pmd/rules/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
+ * @since 0.4
  */
 package com.qulice.pmd.rules;

--- a/qulice-pmd/src/test/java/com/qulice/pmd/FilesTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/FilesTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
  * Test case for {@link Files} class.
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
+ * @since 0.7
  */
 public final class FilesTest {
 

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
  * Test case for {@link PMDValidator} class.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class PMDValidatorTest {

--- a/qulice-pmd/src/test/java/com/qulice/pmd/package-info.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.pmd;

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -49,6 +49,7 @@ import org.apache.commons.io.filefilter.WildcardFileFilter;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public interface Environment {

--- a/qulice-spi/src/main/java/com/qulice/spi/ValidationException.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/ValidationException.java
@@ -34,6 +34,7 @@ package com.qulice.spi;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class ValidationException extends Exception {
 

--- a/qulice-spi/src/main/java/com/qulice/spi/Validator.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Validator.java
@@ -34,6 +34,7 @@ package com.qulice.spi;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public interface Validator {
 

--- a/qulice-spi/src/main/java/com/qulice/spi/package-info.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.spi;

--- a/qulice-spi/src/test/java/com/qulice/spi/EnvironmentTest.java
+++ b/qulice-spi/src/test/java/com/qulice/spi/EnvironmentTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
  * Test case for {@link Environment}.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 public final class EnvironmentTest {
 

--- a/qulice-spi/src/test/java/com/qulice/spi/package-info.java
+++ b/qulice-spi/src/test/java/com/qulice/spi/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.spi;

--- a/qulice-xml/src/main/java/com/qulice/xml/Prettifier.java
+++ b/qulice-xml/src/main/java/com/qulice/xml/Prettifier.java
@@ -43,6 +43,7 @@ import javax.xml.transform.stream.StreamSource;
  *
  * @author Krzysztof Krason (Krzysztof.Krason@gmail.com)
  * @version $Id$
+ * @since 0.9
  */
 public final class Prettifier {
 

--- a/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
+++ b/qulice-xml/src/main/java/com/qulice/xml/XmlValidator.java
@@ -53,6 +53,7 @@ import org.xml.sax.SAXException;
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings({ "PMD.AvoidInstantiatingObjectsInLoops",
     "PMD.ExceptionAsFlowControl" })

--- a/qulice-xml/src/main/java/com/qulice/xml/package-info.java
+++ b/qulice-xml/src/main/java/com/qulice/xml/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.xml;

--- a/qulice-xml/src/test/java/com/qulice/xml/XmlValidatorTest.java
+++ b/qulice-xml/src/test/java/com/qulice/xml/XmlValidatorTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
  * Test case for {@link XmlValidator} class.
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 @SuppressWarnings("PMD.TooManyMethods")
 public final class XmlValidatorTest {

--- a/qulice-xml/src/test/java/com/qulice/xml/package-info.java
+++ b/qulice-xml/src/test/java/com/qulice/xml/package-info.java
@@ -33,5 +33,6 @@
  *
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
+ * @since 0.3
  */
 package com.qulice.xml;


### PR DESCRIPTION
#648
* added since tags to classes, fixed non-static access for two variables

Since tags are not using  patch version, only the first two. Those make more sense as it is not always known ahead of time which version will be released next, patch one or minor one.