### PR TITLE
#666 Disable static method check for ITs and small fixes

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -382,7 +382,7 @@
         <module name="com.qulice.checkstyle.JavadocLocationCheck"/>
         <module name="com.qulice.checkstyle.ConstantUsageCheck"/>
         <module name="com.qulice.checkstyle.NonStaticMethodCheck">
-            <property name="excludeFileNamePattern" value=".*Test\.java"/>
+            <property name="excludeFileNamePattern" value=".*(Test|IT|ITCase)\.java"/>
         </module>
         <module name="com.qulice.checkstyle.ProtectedMethodInFinalClassCheck"/>
         <module name="com.qulice.checkstyle.FinalSemicolonInTryWithResourcesCheck"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -405,6 +405,32 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator cannot demand methods to be static in files with
+     * names ending with {@code ITCase}.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void acceptsNonStaticMethodsInIt() throws Exception {
+        this.validateCheckstyle(
+            "ValidIT.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
+     * CheckstyleValidator cannot demand methods to be static in files with
+     * names ending with {@code IT}.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void acceptsNonStaticMethodsInItCases() throws Exception {
+        this.validateCheckstyle(
+            "ValidITCase.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
      * CheckstyleValidator does not produce errors when last thing
      * in file are imports. The only exception that should be thrown is
      * qulice ValidationException.

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/config.xml
@@ -8,6 +8,8 @@
  -->
 <module name="Checker">
     <module name="TreeWalker">
-        <module name="com.qulice.checkstyle.NonStaticMethodCheck"/>
+        <module name="com.qulice.checkstyle.NonStaticMethodCheck">
+            <property name="excludeFileNamePattern" value=".*(Test|IT|ITCase)\.java"/>
+        </module>
     </module>
 </module>

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidIT.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidIT.java
@@ -1,0 +1,20 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public class ValidIT {
+    /**
+     * Any action.
+     * @return Any string
+     */
+    public final String action() {
+        return "something";
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidITCase.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidITCase.java
@@ -1,0 +1,20 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public class ValidITCase {
+    /**
+     * Any action.
+     * @return Any string
+     */
+    public final String action() {
+        return "something";
+    }
+}

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -123,7 +123,6 @@ public interface Environment {
 
     /**
      * Mock of {@link Environment}.
-     * @checkstyle NonStaticMethodCheck (500 lines)
      */
     final class Mock implements Environment {
         /**

--- a/years.sh
+++ b/years.sh
@@ -3,7 +3,5 @@
 if (grep -L -r 2011-`date +%Y` --exclude-dir ".git" --exclude ".*" --exclude-dir "est" --exclude "*.yml" --exclude "*.md" --exclude-dir "target" --exclude-dir "it" . | egrep -v "(qulice-pmd/src/test/resources|qulice-checkstyle/src/test/resources|qulice-xml/src/test/resources|src/site/resources/CNAME|qulice-codenarc/src/main/resources/com/qulice/codenarc/rules.txt|qulice-gradle-plugin/src/main/resources/META-INF/gradle-plugins/qulice-plugin.properties|years.sh)"); then
     echo "Files above have wrong years in copyrights"
     exit 1
-else
-    exit 0;
 fi
 


### PR DESCRIPTION
For #666:
* Extend pattern for `NonStaticMethodCheck`
* Add tests
* Remove suppressions
* Remove obsolete branch in bash