### PR TITLE
#411 Allow proper indentation in complex annotations

### DIFF
--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>6.14</version>
+            <version>6.15</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.abego.treelayout</groupId>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -379,6 +379,11 @@ public final class CheckstyleValidatorTest {
     /**
      * CheckstyleValidator can allow proper indentation in complex annotations.
      * @throws Exception If something wrong happens inside
+     * @todo #411:30min Sample code provided in #411 should be considered as
+     *  invalid. Find a way how to do that by either custom check, or updating
+     *  Checkstyle whenever IndentationCheck there will be more reliable. As for
+     *  Checkstyle 6.15 there's no ready solution for that. Right now Qulice
+     *  allows both correct and incorrect code from #411.
      */
     @Test
     public void allowsProperIndentationInAnnotations() throws Exception {

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -377,6 +377,18 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator can allow proper indentation in complex annotations.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void allowsProperIndentationInAnnotations() throws Exception {
+        this.validateCheckstyle(
+            "AnnotationIndentation.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
      * Fail validation with extra semicolon in the end
      * of try-with-resources head.
      * @throws Exception If something wrong happens inside

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/AnnotationIndentation.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/AnnotationIndentation.java
@@ -1,0 +1,20 @@
+/**
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+@SuppressWarnings(
+    {
+        "PMD.TooManyMethods",
+        "PMD.ExcessiveImports",
+        "PMD.AvoidDuplicateLiterals"
+    }
+)
+public final class AnnotationIndentation {
+}


### PR DESCRIPTION
For #411:
* Update Checkstyle to 6.15
* Add test confirming that indentation works correctly now