### PR TITLE
#655 Prohibit usages of 'CharEncoding'

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -149,6 +149,11 @@
         <property name="message" value="Using class as a lock is a bad practice (use class variable instead)"/>
     </module>
     <module name="RegexpSingleline">
+        <property name="format" value="org\.apache\.commons\.(codec|lang3?)\.CharEncoding"/>
+        <property name="fileExtensions" value="java"/>
+        <property name="message" value="Use 'java.nio.charset.StandardCharsets' instead"/>
+    </module>
+    <module name="RegexpSingleline">
         <property name="format" value="^(?! *(/\*\*|\*|//)).*[\.\-\+%/\*&lt;&gt;] *$"/>
         <property name="fileExtensions" value="java"/>
         <property name="message" value="Line cannot end with this symbol, move it to the next line"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -193,6 +193,32 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator can report Apache Commons {@code CharEncoding} class
+     * usages.
+     * @throws Exception when error.
+     */
+    @Test
+    public void reportsAllCharEncodingUsages() throws Exception {
+        final String violation = StringUtils.join(
+            "DoNotUseCharEncoding.java[%s]: ",
+            "Use java.nio.charset.StandardCharsets instead"
+        );
+        this.validateCheckstyle(
+            "DoNotUseCharEncoding.java", false,
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    String.format(violation, "6"),
+                    String.format(violation, "7"),
+                    String.format(violation, "8"),
+                    String.format(violation, "22"),
+                    String.format(violation, "23"),
+                    String.format(violation, "24")
+                )
+            )
+        );
+    }
+
+    /**
      * CheckstyleValidator accepts the valid indentation
      * refused by forceStrictCondition.
      * @throws Exception when error.

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -52,7 +52,7 @@ import org.junit.Test;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.3
- * @checkstyle MultipleStringLiterals (300 lines)
+ * @checkstyle MultipleStringLiterals (400 lines)
  * @todo #412:30min Split this class into smaller ones and remove PMD
  *  exclude `TooManyMethods`. Good candidates for moving out of this class
  *  are all that use `validateCheckstyle` method.

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/DoNotUseCharEncoding.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/DoNotUseCharEncoding.java
@@ -1,0 +1,26 @@
+/**
+ * Hello.
+ */
+package foo;
+
+import org.apache.commons.codec.CharEncoding;
+import org.apache.commons.lang.CharEncoding;
+import org.apache.commons.lang3.CharEncoding;
+
+/**
+ * Simple.
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public final class DoNotUseCharEncoding {
+    /**
+     * Act.
+     */
+    public void act() {
+        System.out.println(this + CharEncoding.UTF_8);
+        System.out.println(org.apache.commons.lang3.CharEncoding.UTF_8);
+        System.out.println(org.apache.commons.lang.CharEncoding.ISO_8859_1);
+        System.out.println(org.apache.commons.codec.CharEncoding.UTF_16);
+    }
+}


### PR DESCRIPTION
For #655:
* Use regexp rule to prohibit usages of `CharEncoding`
* Add test case