### PR TITLE
Invalidate methods that throw from a catch that could otherwise be static

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -108,9 +108,10 @@ public final class NonStaticMethodCheck extends Check {
         if (modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null) {
             return;
         }
+        final int maxlen = NonStaticMethodCheck.ONLY_THROW_LEN;
         final boolean onlythrow =
             method.branchContains(TokenTypes.LITERAL_THROW)
-                && this.getMethodLength(method) == ONLY_THROW_LEN;
+                && this.getMethodLength(method) == maxlen;
         if (!AnnotationUtility.containsAnnotation(method, "Override")
             && !isInAbstractOrNativeMethod(method)
             && !method.branchContains(TokenTypes.LITERAL_THIS)

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/NonStaticMethodCheck.java
@@ -101,10 +101,13 @@ public final class NonStaticMethodCheck extends Check {
         if (modifiers.findFirstToken(TokenTypes.LITERAL_STATIC) != null) {
             return;
         }
+        final boolean thrownocatch =
+            method.branchContains(TokenTypes.LITERAL_THROW)
+                && !method.branchContains(TokenTypes.LITERAL_CATCH);
         if (!AnnotationUtility.containsAnnotation(method, "Override")
             && !isInAbstractOrNativeMethod(method)
             && !method.branchContains(TokenTypes.LITERAL_THIS)
-            && !method.branchContains(TokenTypes.LITERAL_THROW)) {
+            && !thrownocatch) {
             final int line = method.getLineNo();
             this.log(
                 line,

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Invalid.java
@@ -16,4 +16,11 @@ public class InvalidTest {
     public synchronized String name() {
         return "method with non-native and non-abstract modifier";
     }
+    public String name() {
+        try {
+            ThatClass.name();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/Valid.java
@@ -39,4 +39,13 @@ public class Bar {
         // this method is not yet implemented
         throw new UnsupportedOperationException();
     }
+
+    public void anotherThrowsExceptionMethod() {
+        // this methods throws an exception with a description that spans
+        // more than one and and has a commented out line of code.
+        // throw new OldException();
+        throw new IllegalStateException("This method is not to be called," +
+            " because it has a really long description that spans more than" +
+            " one line.");
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/NonStaticMethodCheck/violations.txt
@@ -2,3 +2,4 @@
 9:This method must be static, because it does not refer to "this"
 12:This method must be static, because it does not refer to "this"
 16:This method must be static, because it does not refer to "this"
+19:This method must be static, because it does not refer to "this"


### PR DESCRIPTION
#623 Updated code and tests to find methods that should static if they catch and re-throw an exception.