### PR TITLE
#676 npe dependency validator

### DIFF
--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/DefaultMavenEnvironment.java
@@ -31,6 +31,7 @@ package com.qulice.maven;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
 import com.jcabi.log.Logger;
@@ -238,10 +239,11 @@ public final class DefaultMavenEnvironment implements MavenEnvironment {
 
     @Override
     public Collection<String> excludes(final String checker) {
-        return Collections2.transform(
+        final Collection<String> excludes = Collections2.transform(
             this.exc,
             new DefaultMavenEnvironment.CheckerExcludes(checker)
         );
+        return Collections2.filter(excludes, Predicates.notNull());
     }
 
     /**

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -133,8 +133,8 @@ public class DefaultMavenEnvironmentTest {
      * DefaultMavenEnvironment can produce empty collection when no matches
      * with checker.
      * @throws Exception If something wrong happens inside
-     * @todo Ideally integration test required to reproduce NPE described in
-     *  #676. It should contains at least one exclude rule in
+     * @todo #676:30min Ideally integration test required to reproduce NPE.
+     *  It should contains at least one exclude rule in
      *  configuration.excludes block and dependency (I got it
      *  locally with org.hibernate:hibernate-annotations:3.5.6-Final.
      *  I suppose, dependency must be compile-time scope but it is only my

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -136,7 +136,7 @@ public class DefaultMavenEnvironmentTest {
      * @todo #676:30min Ideally integration test is required to reproduce NPE
      *  in issue #676.
      *  To reproduce problem firstly revert changes marked with #676, then
-     *  add to pom.xml of it project at least one exclude rule in
+     *  add to pom.xml of IT project at least one exclude rule in
      *  configuration.excludes block and dependency (in my case worked
      *  org.hibernate:hibernate-annotations:3.5.6-Final).
      *  Suggestion is that dependency must be compile-time scope as far as

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -135,7 +135,7 @@ public class DefaultMavenEnvironmentTest {
      * @throws Exception If something wrong happens inside
      * @todo #676:30min Ideally integration test is required to reproduce NPE
      *  in issue #676.
-     *  To reproduce problem firstly revert changes marked with #676, than
+     *  To reproduce problem firstly revert changes marked with #676, then
      *  add to pom.xml of it project at least one exclude rule in
      *  configuration.excludes block and dependency (in my case worked
      *  org.hibernate:hibernate-annotations:3.5.6-Final).

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -135,7 +135,8 @@ public class DefaultMavenEnvironmentTest {
      * @throws Exception If something wrong happens inside
      * @todo #676:30min Ideally integration test is required to reproduce NPE
      *  in issue #676.
-     *  To reproduce problem - add to pom.xml at least one exclude rule in
+     *  To reproduce problem firstly revert changes marked with #676, than
+     *  add to pom.xml of it project at least one exclude rule in
      *  configuration.excludes block and dependency (in my case worked
      *  org.hibernate:hibernate-annotations:3.5.6-Final).
      *  Suggestion is that dependency must be compile-time scope as far as

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -133,7 +133,7 @@ public class DefaultMavenEnvironmentTest {
      * DefaultMavenEnvironment can produce empty collection when no matches
      * with checker.
      * @throws Exception If something wrong happens inside
-     * @todo #676:30min Ideally integration test required to reproduce NPE
+     * @todo #676:30min Ideally integration test is required to reproduce NPE
      *  in issue #676.
      *  To reproduce problem - add to pom.xml at least one exclude rule in
      *  configuration.excludes block and dependency (in my case worked

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -133,12 +133,13 @@ public class DefaultMavenEnvironmentTest {
      * DefaultMavenEnvironment can produce empty collection when no matches
      * with checker.
      * @throws Exception If something wrong happens inside
-     * @todo #676:30min Ideally integration test required to reproduce NPE.
-     *  It should contains at least one exclude rule in
-     *  configuration.excludes block and dependency (I got it
-     *  locally with org.hibernate:hibernate-annotations:3.5.6-Final.
-     *  I suppose, dependency must be compile-time scope but it is only my
-     *  suggestions as far as junit with hamcrest didn't work.
+     * @todo #676:30min Ideally integration test required to reproduce NPE
+     *  in issue #676.
+     *  To reproduce problem - add to pom.xml at least one exclude rule in
+     *  configuration.excludes block and dependency (in my case worked
+     *  org.hibernate:hibernate-annotations:3.5.6-Final).
+     *  Suggestion is that dependency must be compile-time scope as far as
+     *  JUnit didn't work as test-scope dependency.
      */
     @Test
     public final void producesEmptyExcludesWhenNoMatches() throws Exception {

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -128,4 +128,24 @@ public class DefaultMavenEnvironmentTest {
             Matchers.notNullValue()
         );
     }
+
+    /**
+     * DefaultMavenEnvironment can produce empty collection when no matches
+     * with checker.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public final void emptyExcludesWhenNotMatchesChecker() throws Exception {
+        final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
+        env.setExcludes(
+            ImmutableList.<String>builder()
+                .add("checkstyle:**/src/ex1/Main.groovy")
+                .add("pmd:**/src/ex2/Main2.groovy")
+                .build()
+        );
+        MatcherAssert.assertThat(
+            env.excludes("dependencies"),
+            Matchers.<String>empty()
+        );
+    }
 }

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DefaultMavenEnvironmentTest.java
@@ -133,19 +133,25 @@ public class DefaultMavenEnvironmentTest {
      * DefaultMavenEnvironment can produce empty collection when no matches
      * with checker.
      * @throws Exception If something wrong happens inside
+     * @todo Ideally integration test required to reproduce NPE described in
+     *  #676. It should contains at least one exclude rule in
+     *  configuration.excludes block and dependency (I got it
+     *  locally with org.hibernate:hibernate-annotations:3.5.6-Final.
+     *  I suppose, dependency must be compile-time scope but it is only my
+     *  suggestions as far as junit with hamcrest didn't work.
      */
     @Test
-    public final void emptyExcludesWhenNotMatchesChecker() throws Exception {
+    public final void producesEmptyExcludesWhenNoMatches() throws Exception {
         final DefaultMavenEnvironment env = new DefaultMavenEnvironment();
         env.setExcludes(
-            ImmutableList.<String>builder()
-                .add("checkstyle:**/src/ex1/Main.groovy")
-                .add("pmd:**/src/ex2/Main2.groovy")
-                .build()
+            ImmutableList.of(
+                "checkstyle:**/src/ex1/Main.groovy",
+                "pmd:**/src/ex2/Main2.groovy"
+            )
         );
         MatcherAssert.assertThat(
             env.excludes("dependencies"),
-            Matchers.<String>empty()
+            Matchers.empty()
         );
     }
 }


### PR DESCRIPTION
For issue #676 
Problem was in `DefaultMavenEnvironment.exludes` when Collection [null, null, null] returned if exclusion don't match checker 'dependecies'
Fixed problem, added not null filter for method DefaultMavenEnvironment.exludes, so now empty collection turns back if no matchings