### PR TITLE
#675: excluded non-static non-transient pmd rule

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -32,10 +32,10 @@
  * @version $Id$
  -->
 <ruleset name="Qulice Ruleset"
-    xmlns="http://pmd.sf.net/ruleset/1.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-    xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
 
     <description>
         This ruleset checks code for potential mess
@@ -46,15 +46,17 @@
     </rule>
     <rule ref="rulesets/java/empty.xml"/>
     <rule ref="rulesets/java/braces.xml"/>
-    <rule ref="rulesets/java/clone.xml" />
-    <rule ref="rulesets/java/codesize.xml" />
+    <rule ref="rulesets/java/clone.xml"/>
+    <rule ref="rulesets/java/codesize.xml"/>
     <rule ref="rulesets/java/design.xml"/>
     <rule ref="rulesets/java/finalizers.xml"/>
     <rule ref="rulesets/java/imports.xml"/>
     <rule ref="rulesets/java/j2ee.xml">
         <exclude name="DoNotUseThreads"/>
     </rule>
-    <rule ref="rulesets/java/javabeans.xml"/>
+    <rule ref="rulesets/java/javabeans.xml">
+        <exclude name="BeanMembersShouldSerialize"/>
+    </rule>
     <rule ref="rulesets/java/logging-java.xml">
         <exclude name="GuardLogStatementJavaUtil"/>
     </rule>
@@ -87,11 +89,13 @@
     </rule>
 
     <rule name="ProhibitPlainJunitAssertionsRule"
-        message="Avoid using Plain JUnit assertions"
-        class="com.qulice.pmd.rules.ProhibitPlainJunitAssertionsRule">
+          message="Avoid using Plain JUnit assertions"
+          class="com.qulice.pmd.rules.ProhibitPlainJunitAssertionsRule">
         <description>
-            Instead of using plain JUnit assertions like org.junit.Assert.assert*
-            junit.framework.Assert.assert* - use Matchers from package org.hamcrest
+            Instead of using plain JUnit assertions like
+            org.junit.Assert.assert*
+            junit.framework.Assert.assert* - use Matchers from package
+            org.hamcrest
         </description>
     </rule>
 
@@ -160,7 +164,8 @@
           language="java"
           class="net.sourceforge.pmd.lang.rule.XPathRule">
         <description>
-            Avoid putting anything other than field assignments into constructors.
+            Avoid putting anything other than field assignments into
+            constructors.
             The only exception should be calling other constructors
             or calling super class constructor.
         </description>

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -32,10 +32,10 @@
  * @version $Id$
  -->
 <ruleset name="Qulice Ruleset"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    xmlns="http://pmd.sf.net/ruleset/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+    xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
 
     <description>
         This ruleset checks code for potential mess
@@ -46,8 +46,8 @@
     </rule>
     <rule ref="rulesets/java/empty.xml"/>
     <rule ref="rulesets/java/braces.xml"/>
-    <rule ref="rulesets/java/clone.xml"/>
-    <rule ref="rulesets/java/codesize.xml"/>
+    <rule ref="rulesets/java/clone.xml" />
+    <rule ref="rulesets/java/codesize.xml" />
     <rule ref="rulesets/java/design.xml"/>
     <rule ref="rulesets/java/finalizers.xml"/>
     <rule ref="rulesets/java/imports.xml"/>
@@ -89,13 +89,11 @@
     </rule>
 
     <rule name="ProhibitPlainJunitAssertionsRule"
-          message="Avoid using Plain JUnit assertions"
-          class="com.qulice.pmd.rules.ProhibitPlainJunitAssertionsRule">
+        message="Avoid using Plain JUnit assertions"
+        class="com.qulice.pmd.rules.ProhibitPlainJunitAssertionsRule">
         <description>
-            Instead of using plain JUnit assertions like
-            org.junit.Assert.assert*
-            junit.framework.Assert.assert* - use Matchers from package
-            org.hamcrest
+            Instead of using plain JUnit assertions like org.junit.Assert.assert*
+            junit.framework.Assert.assert* - use Matchers from package org.hamcrest
         </description>
     </rule>
 
@@ -164,8 +162,7 @@
           language="java"
           class="net.sourceforge.pmd.lang.rule.XPathRule">
         <description>
-            Avoid putting anything other than field assignments into
-            constructors.
+            Avoid putting anything other than field assignments into constructors.
             The only exception should be calling other constructors
             or calling super class constructor.
         </description>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
@@ -91,12 +91,6 @@ public final class PMDValidatorTest {
         "Avoid using Plain JUnit assertions";
 
     /**
-     * Template for using non transient fields.
-     */
-    private static final String NON_TRANSIENT =
-        "Found non-transient, non-static member.";
-
-    /**
      * PMDValidator can find violations in Java file(s).
      * @throws Exception If something wrong happens inside.
      */
@@ -507,7 +501,9 @@ public final class PMDValidatorTest {
         new PMDAssert(
             file, Matchers.is(true),
             Matchers.not(
-                Matchers.containsString(PMDValidatorTest.NON_TRANSIENT)
+                Matchers.containsString(
+                    "Found non-transient, non-static member."
+                )
             )
         ).validate();
     }

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
@@ -91,6 +91,12 @@ public final class PMDValidatorTest {
         "Avoid using Plain JUnit assertions";
 
     /**
+     * Template for using non transient fields.
+     */
+    private static final String NON_TRANSIENT =
+        "Found non-transient, non-static member.";
+
+    /**
      * PMDValidator can find violations in Java file(s).
      * @throws Exception If something wrong happens inside.
      */
@@ -487,6 +493,21 @@ public final class PMDValidatorTest {
                 Matchers.containsString(
                     PMDValidatorTest.PLAIN_ASSERTIONS
                 )
+            )
+        ).validate();
+    }
+
+    /**
+     * PMDValidator can allow non-static, non-transient fields.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void allowNonTransientFields() throws Exception {
+        final String file = "AllowNonTransientFields.java";
+        new PMDAssert(
+            file, Matchers.is(true),
+            Matchers.not(
+                Matchers.containsString(PMDValidatorTest.NON_TRANSIENT)
             )
         ).validate();
     }

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PMDValidatorTest.java
@@ -496,7 +496,7 @@ public final class PMDValidatorTest {
      * @throws Exception If something wrong happens inside.
      */
     @Test
-    public void allowNonTransientFields() throws Exception {
+    public void allowsNonTransientFields() throws Exception {
         final String file = "AllowNonTransientFields.java";
         new PMDAssert(
             file, Matchers.is(true),

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/AllowNonTransientFields.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/AllowNonTransientFields.java
@@ -1,0 +1,15 @@
+package foo;
+
+public final class AllowNonTransientFields {
+
+    private final int nontransient;
+
+    public AllowNonTransientFields(final int a) {
+        this.nontransient = a;
+    }
+
+    public int field() {
+        return nontransient;
+    }
+
+}


### PR DESCRIPTION
For issue #675 
Added test to check if class can contain non-static non-transient field. Test failed.
Fixed test - excluded rule `BeanMembersShouldSerialize ` from ruleset. 