### PR TITLE
#660 implemented AbbreviationsAsWordInNameCheck

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -316,6 +316,10 @@
         <module name="RedundantModifier"/>
 
         <!-- Checks for Naming Conventions. -->
+        <module name="AbbreviationAsWordInNameCheck">
+            <property name="allowedAbbreviations" value="IT"/>
+            <property name="allowedAbbreviationLength" value="1"/>
+        </module>
         <module name="AbstractClassName"/>
         <module name="ClassTypeParameterName"/>
         <module name="ConstantName"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -584,6 +584,65 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator can reject uppercase Abbreviations in naming
+     * outside of final static fields.
+     *
+     * @throws Exception In case of error
+     */
+    @Test
+    public void rejectsUppercaseAbbreviations() throws Exception {
+        final String result = this.runValidation(
+            "InvalidAbbreviationAsWordInNameXML.java", false
+        );
+        final String violation = StringUtils.join(
+            "InvalidAbbreviationAsWordInNameXML.java[%s]: ",
+            "Abbreviation in name '%s' ",
+            "must contain no more than '1' capital letters. ",
+            "(AbbreviationAsWordInNameCheck)"
+        );
+        MatcherAssert.assertThat(
+            result,
+            Matchers.stringContainsInOrder(
+                Arrays.asList(
+                    String.format(
+                        violation, "13", "InvalidAbbreviationAsWordInNameXML"
+                    ),
+                    String.format(
+                        violation, "17", "InvalidHTML"
+                    )
+                )
+            )
+        );
+    }
+
+    /**
+     * CheckstyleValidator can allow IT as an uppercase abbreviation.
+     *
+     * @throws Exception In case of error
+     */
+    @Test
+    public void allowsITUppercaseAbbreviation() throws Exception {
+        this.validateCheckstyle(
+            "ValidAbbreviationAsWordInNameIT.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
+     * CheckstyleValidator can allow final static fields and overrides
+     * to have uppercase abbreviations.
+     *
+     * @throws Exception In case of error
+     */
+    @Test
+    public void allowsUppercaseAbbreviationExceptions() throws Exception {
+        this.validateCheckstyle(
+            "ValidAbbreviationAsWordInName.java", true,
+            Matchers.containsString(CheckstyleValidatorTest.NO_VIOLATIONS)
+        );
+    }
+
+    /**
      * Convert file name to URL.
      * @param file The file
      * @return The URL

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -584,7 +584,7 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
-     * CheckstyleValidator can reject uppercase Abbreviations in naming
+     * CheckstyleValidator can reject uppercase abbreviations in naming
      * outside of final static fields.
      *
      * @throws Exception In case of error

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/InvalidAbbreviationAsWordInNameXML.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/InvalidAbbreviationAsWordInNameXML.java
@@ -1,0 +1,19 @@
+/**
+ * Hello.
+ */
+package foo.bar;
+
+/**
+ * Uppercase abbreviation XML in class name is not allowed.
+ *
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public class InvalidAbbreviationAsWordInNameXML {
+    /**
+     * Uppercase abbreviation HTML in nested class name is not allowed.
+     */
+    class InvalidHTML {
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInName.java
@@ -1,0 +1,32 @@
+/**
+ * Hello.
+ */
+package foo.bar;
+
+/**
+ * Classname contains no abbreviations.
+ * Contains overridden method for which otherwise invalid uppercase use is
+ * allowed.
+ *
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public class ValidAbbreviationAsWordInName extends SomeClass {
+
+    /**
+     * Example final static is valid and does not need to be in camelcase.
+     */
+    private static final String CONST_VALUE = "foo";
+
+    @Override
+    public final String UPPERCASE() {
+        return CONST_VALUE;
+    }
+
+    /**
+     * ValidInnerHtml example class having the abbreviation in camelcase.
+     */
+    public class ValidInnerHtml {
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
@@ -4,7 +4,7 @@
 package foo.bar;
 
 /**
- * Uppercase abbreviation IT in class name is allowed as an exception.
+ * Uppercase abbreviation IT in class name is allowed.
  * @author John Smith (john@example.com)
  * @version $Id$
  * @since 1.0

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
@@ -1,0 +1,18 @@
+/**
+ * Hello.
+ */
+package foo.bar;
+
+/**
+ * Uppercase abbreviation IT in class name is allowed as an exception.
+ * @author John Smith (john@example.com)
+ * @version $Id$
+ * @since 1.0
+ */
+public class ValidAbbreviationAsWordInNameIT {
+    /**
+     * Valid name on inner class, because the IT abbreviation is allow.
+     */
+    class ValidInnerIT {
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidAbbreviationAsWordInNameIT.java
@@ -11,7 +11,7 @@ package foo.bar;
  */
 public class ValidAbbreviationAsWordInNameIT {
     /**
-     * Valid name on inner class, because the IT abbreviation is allow.
+     * Valid name on inner class, because the IT abbreviation is allowed.
      */
     class ValidInnerIT {
     }


### PR DESCRIPTION
#660 AbbreviationAsWordInNameCheck configured:
* Set allowed abbreviation size to 1 so to not allow those
* Set "IT" as the only exception as allowed uppercase abbreviation
* Static final fields as well as overrides are not checked by default and needed no config

Added tests for:
* Abbreviations XML/HTML are detected as standard violations
* IT is not a violation
* Static final fields are not checked
* Correctly named classes pass the check
* Overrides are not checked