### PR TITLE
#760 PMD's AvoidDuplicateLiterals is not equivalent to original MultipleStringLiteralsCheck

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -67,6 +67,9 @@
             <property name="maxDuplicateLiterals">
                 <value>2</value>
             </property>
+            <property name="skipAnnotations">
+                <value>true</value>
+            </property>
         </properties>
     </rule>
     <rule ref="rulesets/java/sunsecure.xml"/>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -564,7 +564,7 @@ public final class PmdValidatorTest {
     }
 
     /**
-     * PmdValidator can allow duplicates literals in annotations.
+     * PmdValidator can allow duplicate literals in annotations.
      * @throws Exception If something wrong happens inside.
      */
     @Test

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -562,4 +562,19 @@ public final class PmdValidatorTest {
             )
         ).validate();
     }
+
+    /**
+     * PmdValidator can allow duplicates literals in annotations.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void allowsDuplicateLiteralsInAnnotations() throws Exception {
+        new PmdAssert(
+            "AllowsDuplicateLiteralsInAnnotations.java",
+            Matchers.is(true),
+            Matchers.not(
+                Matchers.containsString("AvoidDuplicateLiterals")
+            )
+        ).validate();
+    }
 }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/AllowsDuplicateLiteralsInAnnotations.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/AllowsDuplicateLiteralsInAnnotations.java
@@ -1,0 +1,15 @@
+package com.qulice.pmd;
+
+@SuppressWarnings("unchecked")
+public final class AllowsDuplicateLiteralsInAnnotations {
+
+    @SuppressWarnings("unchecked")
+    public void methodOne() {
+        // empty body
+    }
+
+    @SuppressWarnings("unchecked")
+    public void methodTwo() {
+        // empty body
+    }
+}


### PR DESCRIPTION
#760 PMD's AvoidDuplicateLiterals is not equivalent to original MultipleStringLiteralsCheck

I have changed skipAnnotations property to true, which allows AvoidDuplicateLiterals to skip check for Annotations