### PR TITLE
#863 getting rid of abstract naming rules

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -322,7 +322,6 @@
             <property name="allowedAbbreviations" value="IT"/>
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
-        <module name="AbstractClassName"/>
         <module name="ClassTypeParameterName"/>
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName">

--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -110,6 +110,7 @@
     <rule ref="rulesets/java/naming.xml">
         <exclude name="ShortClassName"/>
         <exclude name="ShortVariable"/>
+        <exclude name="AbstractNaming"/>
     </rule>
 
     <rule ref="rulesets/java/strictexception.xml">


### PR DESCRIPTION
#863 Abstract naming rules don't match well with new `Envelops` so removing those rules.