### PR TITLE
#823 remove author and version tags

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -74,12 +74,6 @@ public final class JavadocTagsCheck extends AbstractCheck {
     @Override
     public void init() {
         this.tags.put(
-            "author",
-            // @checkstyle LineLength (1 line)
-            Pattern.compile("^([A-Z](\\.|[a-z]+) )+\\([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}\\)$")
-        );
-        this.tags.put("version", Pattern.compile("^\\$Id.*\\$$"));
-        this.tags.put(
             "since",
             // @checkstyle LineLength (1 line)
             Pattern.compile("^\\d+(\\.\\d+){1,2}(\\.[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$")


### PR DESCRIPTION
#823 Make  `@author` and `@version` tags prohibited.