### PR TITLE
#925 fix error with commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
                 <artifactId>antlr4-runtime</artifactId>
                 <version>4.7.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.7</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/qulice-maven-plugin/src/it/pmd-violations/pom.xml
+++ b/qulice-maven-plugin/src/it/pmd-violations/pom.xml
@@ -37,6 +37,10 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>pmd-violations</name>
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
     <build>
         <plugins>
             <plugin>

--- a/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
+++ b/qulice-maven-plugin/src/it/pmd-violations/src/main/java/com/qulice/foo/Violations.java
@@ -29,6 +29,9 @@
  */
 package com.qulice.foo;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 /**
  * Sample class.
  * @since 1.0
@@ -99,6 +102,13 @@ public final class Violations {
         @Override
         public String toString() {
             return this.name;
+        }
+
+        public String something() {
+            return Stream.of(" one", " two")
+                .map(str -> str.trim())
+                .collect(Collectors.joining());
+
         }
     }
 }


### PR DESCRIPTION
#925 
commons-lang3 version we were using from jcabi-parent was incompatible with the one from PMD, added correct version to deps, and added a test to guard that change.
