### PR TITLE
#848 dont require javadoc for methods in tests

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -169,9 +169,11 @@
         <property name="fileExtensions" value="java"/>
     </module>
 
-    <!--
-    Enable suppressions
-    -->
+    <module name="SuppressionFilter">
+        <property name="file" value="${project.basedir}/src/main/resources/com/qulice/checkstyle/suppressions.xml"/>
+        <property name="optional" value="false"/>
+    </module>
+
     <module name="TreeWalker">
         <property name="cacheFile" value="${cache.file}" />
 

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <suppress checks="JavadocMethod" files=".+(Test|ITCase|IT).java" />
+</suppressions>

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/suppressions.xml
@@ -1,6 +1,37 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN" "https://checkstyle.org/dtds/suppressions_1_2.dtd">
-
+<!--
+ *
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @link http://checkstyle.sourceforge.net/config.html
+ -->
 <suppressions>
     <suppress checks="JavadocMethod" files=".+(Test|ITCase|IT).java" />
 </suppressions>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -53,7 +53,11 @@ import org.junit.Test;
  *  exclude `TooManyMethods`. Good candidates for moving out of this class
  *  are all that use `validateCheckstyle` method.
  */
-@SuppressWarnings({ "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals" })
+@SuppressWarnings(
+    {
+        "PMD.TooManyMethods", "PMD.AvoidDuplicateLiterals", "PMD.GodClass"
+    }
+)
 public final class CheckstyleValidatorTest {
 
     /**
@@ -165,6 +169,16 @@ public final class CheckstyleValidatorTest {
             false,
             "Indentation (14) must be same or less than"
         );
+    }
+
+    /**
+     * CheckstyleValidator does not report an error when there is no JavaDoc
+     * on method in JUnit tests.
+     * @throws Exception when error.
+     */
+    @Test
+    public void doesNotReportErrorWhenMissingJavadocInTests() throws Exception {
+        this.runValidation("MissingJavadocTest.java", true);
     }
 
     /**

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/MissingJavadocTest.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/MissingJavadocTest.java
@@ -1,0 +1,18 @@
+/*
+ * Hello.
+ */
+package foo;
+
+import org.junit.Test;
+
+/**
+ * Simple.
+ * @since 1.0
+ */
+public class MissingJavadocTest {
+
+    @Test
+    public void testSomething() {
+        return "something";
+    }
+}

--- a/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
+++ b/qulice-maven-plugin/src/it/checkstyle-violations/verify.groovy
@@ -47,5 +47,5 @@ assert log.text.contains('Violations.java[33]: ArrayList should be initialized w
 assert log.text.contains('Violations.java[34]: ArrayList should be initialized with a size parameter')
 assert log.text.findAll('Pdd.java.*: .todo tag has wrong format').empty
 assert !log.text.contains('Got an exception - java.lang.NullPointerException')
-//assert !log.text.contains('SomeTest.java[5]: This method must be static, because it does not refer to "this"')
+assert log.text.findAll('SomeTest.java .+ (JavadocMethodCheck)').isEmpty()
 assert !log.text.contains('IndentationChecks.java[19]: method call rparen at indentation level 12')


### PR DESCRIPTION
#848
* removed requirement for method javadocs in test classes
