### PR TITLE
For #772: Removal of overlapping checks of PMD and checkstyle

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -33,6 +33,19 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * @link http://checkstyle.sourceforge.net/config.html
+ * @todo #772:30min Checkstyle and PMD rules overlap. Let's get rid of
+ *  checkstyle and PMD overlapping rules removing the checkstyle ones and making
+ *  sure that PMD ones have at least the same threshold as the removed
+ *  checkstyle checks (that is, we don't reduce code quality).
+ *  Following checks are equivalent:
+ *  checkstyle -> PMD
+ *  JavaNCSS (method and class) -> NcssMethodCount, NcssConstructorCount,
+ *                                 NcssTypeCount
+ *  CyclomaticComplexity -> CyclomaticComplexity, StdCyclomaticComplexity,
+ *                                 ModifiedCyclomaticComplexity
+ *  NPathComplexity->NPathComplexity
+ *  MethodLength -> ExcessiveMethodLength
+ *  IllegalCatch -> AvoidCatchingGenericException
  -->
 <module name="Checker">
     <!--
@@ -272,7 +285,6 @@
         <module name="AvoidStaticImport" />
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>
-        <module name="UnusedImports"/>
         <module name="ImportOrder"/>
 
         <module name="NoLineWrap"/>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/LocalVariableCouldBeFinalRuleTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.pmd;
+
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringStartsWith;
+import org.junit.Test;
+
+/**
+ * Test case for LocalVariableCouldBeFinal.
+ *
+ * @since 0.18
+ */
+public class LocalVariableCouldBeFinalRuleTest {
+
+    /**
+     * LocalVariableCouldBeFinal can detect when variable is not
+     *  final and shows correct message.
+     *
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public final void detectLocalVariableCouldBeFinal() throws Exception {
+        new PmdAssert(
+            "LocalVariableCouldBeFinal.java",
+            new IsEqual<>(false),
+            new StringStartsWith(
+                String.join(
+                    " ",
+                    "PMD: LocalVariableCouldBeFinal.java[6-6]:",
+                    "Local variable 'nonfinal' could be declared final",
+                    "(LocalVariableCouldBeFinal)"
+                )
+            )
+        ).validate();
+    }
+}

--- a/qulice-pmd/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/UnusedImportsRuleTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.pmd;
+
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.StringStartsWith;
+import org.junit.Test;
+
+/**
+ * Test case for LocalVariableCouldBeFinal.
+ *
+ * @since 0.18
+ */
+public class UnusedImportsRuleTest {
+
+    /**
+     * UnusedImport can detect when the class has an unused import line and
+     * show error message correctly.
+     *
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public final void detectUnusedImportLine() throws Exception {
+        new PmdAssert(
+            "UnusedImports.java",
+            new IsEqual<>(false),
+            new StringStartsWith(
+                String.join(
+                    " ",
+                    "PMD: UnusedImports.java[3-3]: Avoid unused imports such",
+                    "as 'unused.bar.foo.UnusedImport'",
+                    "(UnusedImports)"
+                ).trim()
+            )
+        ).validate();
+    }
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/LocalVariableCouldBeFinal.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/LocalVariableCouldBeFinal.java
@@ -1,0 +1,9 @@
+package foo;
+
+public final class LocalVariableCouldBeFinal {
+
+    public int method() {
+        int nonfinal = 0;
+        return nonfinal;
+    }
+}

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/UnusedImports.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/UnusedImports.java
@@ -1,0 +1,10 @@
+package foo;
+
+import unused.bar.foo.UnusedImport;
+
+public final class UnusedImports {
+
+    public int method() {
+        return null;
+    }
+}


### PR DESCRIPTION
For #772: Removal of overlapping checks of PMD and checkstyle´
- Added tests for `UnusedImports` and `LocalVariableCouldBeFinal` PMD checks]
- Removed those checks from `checkstyle`
- Left puzzle for continuing implementation