### PR TITLE
For #884: Replace FindBugs with SpotBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <module>qulice-maven-plugin</module>
         <module>qulice-pmd</module>
         <module>qulice-spi</module>
+        <module>qulice-spotbugs</module>
         <module>qulice-gradle-plugin</module>
     </modules>
     <description><![CDATA[

--- a/qulice-spotbugs/LICENSE.txt
+++ b/qulice-spotbugs/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2011-2018, Qulice.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met: 1) Redistributions of source code must retain the above
+copyright notice, this list of conditions and the following
+disclaimer. 2) Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution. 3) Neither the name of the Qulice.com nor
+the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/qulice-spotbugs/pom.xml
+++ b/qulice-spotbugs/pom.xml
@@ -41,7 +41,7 @@
     </parent>
     <artifactId>qulice-spotbugs</artifactId>
     <packaging>jar</packaging>
-    <name>qulice-spotbuugs</name>
+    <name>qulice-spotbugs</name>
     <dependencies>
         <dependency>
             <groupId>com.qulice</groupId>

--- a/qulice-spotbugs/pom.xml
+++ b/qulice-spotbugs/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<!--
+ *
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.qulice</groupId>
+        <artifactId>qulice</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>qulice-spotbugs</artifactId>
+    <packaging>jar</packaging>
+    <name>qulice-spotbuugs</name>
+    <dependencies>
+        <dependency>
+            <groupId>com.qulice</groupId>
+            <artifactId>qulice-spi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cactoos</groupId>
+            <artifactId>cactoos</artifactId>
+            <version>0.38</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-log</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Main-Class>com.qulice.findbugs.Wrap</Main-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.github.github</groupId>
+                <artifactId>site-maven-plugin</artifactId>
+                <configuration>
+                    <path>${project.artifactId}</path>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>qulice</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.qulice</groupId>
+                        <artifactId>qulice-maven-plugin</artifactId>
+                        <configuration>
+                            <excludes combine.children="append">
+                                <exclude>duplicatefinder:.*</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/qulice-spotbugs/pom.xml
+++ b/qulice-spotbugs/pom.xml
@@ -49,15 +49,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.cactoos</groupId>
-            <artifactId>cactoos</artifactId>
-            <version>0.38</version>
-        </dependency>
-        <dependency>
-            <groupId>com.jcabi</groupId>
-            <artifactId>jcabi-log</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
@@ -30,22 +30,16 @@
 package com.qulice.spotbugs;
 
 import com.jcabi.log.Logger;
-import com.jcabi.log.VerboseProcess;
 import com.qulice.spi.Environment;
 import com.qulice.spi.ValidationException;
 import com.qulice.spi.Validator;
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.List;
-import java.util.logging.Level;
-import org.cactoos.text.JoinedText;
-import org.cactoos.text.ReplacedText;
-import org.cactoos.text.UncheckedText;
 
 /**
  * Validates source code and compiled binaries with SpotBugs.
  *
- * @since 0.17
+ * @since 0.19
  */
 @SuppressWarnings({"PMD.ExcessiveImports", "PMD.AvoidDuplicateLiterals"})
 public final class SpotBugsValidator implements Validator {
@@ -67,7 +61,7 @@ public final class SpotBugsValidator implements Validator {
 
     @Override
     public String name() {
-        return "FindBugs";
+        return "SpotBugs";
     }
 
     /**
@@ -77,26 +71,7 @@ public final class SpotBugsValidator implements Validator {
      */
     @SuppressWarnings("PMD.AvoidDuplicateLiterals")
     private static String spotbugs(final Environment env) {
-        final List<String> args = new LinkedList<>();
-        args.add("java");
-        args.addAll(SpotBugsValidator.options());
-        args.add(env.basedir().getPath());
-        args.add(env.outdir().getPath());
-        args.add(
-            new UncheckedText(
-                new ReplacedText(
-                    new JoinedText(
-                        ",",
-                        env.classpath()
-                    ),
-                    "\\",
-                    "/"
-                )
-            ).asString()
-        );
-        return new VerboseProcess(
-            new ProcessBuilder(args), Level.INFO, Level.INFO
-        ).stdout();
+        throw new UnsupportedOperationException("spotbugs not implemented");
     }
 
     /**

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.spotbugs;
+
+import com.jcabi.log.Logger;
+import com.jcabi.log.VerboseProcess;
+import com.qulice.spi.Environment;
+import com.qulice.spi.ValidationException;
+import com.qulice.spi.Validator;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Level;
+import org.cactoos.text.JoinedText;
+import org.cactoos.text.ReplacedText;
+import org.cactoos.text.UncheckedText;
+
+/**
+ * Validates source code and compiled binaries with SpotBugs.
+ *
+ * @since 0.17
+ */
+@SuppressWarnings({"PMD.ExcessiveImports", "PMD.AvoidDuplicateLiterals"})
+public final class SpotBugsValidator implements Validator {
+
+    @Override
+    public void validate(final Environment env) throws ValidationException {
+        if (env.outdir().exists()) {
+            if (!env.exclude("spotbugs", "")) {
+                this.check(SpotBugsValidator.spotbugs(env));
+            }
+        } else {
+            Logger.info(
+                this,
+                "No classes at %s, no SpotBugs validation",
+                env.outdir()
+            );
+        }
+    }
+
+    @Override
+    public String name() {
+        return "FindBugs";
+    }
+
+    /**
+     * Start spotbugs and return its output.
+     * @param env Environment
+     * @return Output of spotbugs
+     */
+    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
+    private static String spotbugs(final Environment env) {
+        final List<String> args = new LinkedList<>();
+        args.add("java");
+        args.addAll(SpotBugsValidator.options());
+        args.add(env.basedir().getPath());
+        args.add(env.outdir().getPath());
+        args.add(
+            new UncheckedText(
+                new ReplacedText(
+                    new JoinedText(
+                        ",",
+                        env.classpath()
+                    ),
+                    "\\",
+                    "/"
+                )
+            ).asString()
+        );
+        return new VerboseProcess(
+            new ProcessBuilder(args), Level.INFO, Level.INFO
+        ).stdout();
+    }
+
+    /**
+     * Java options.
+     * @return Options
+     */
+    private static Collection<String> options() {
+        return new LinkedList<>();
+    }
+
+    /**
+     * Check report for errors.
+     * @param report The report
+     * @throws ValidationException If it contains errors
+     */
+    private void check(final String report) throws ValidationException {
+        int total = 0;
+        for (final String line
+            : report.split(System.getProperty("line.separator"))) {
+            if (line.matches("[a-zA-Z ]+: .*")) {
+                Logger.warn(this, "SpotBugs: %s", line);
+                ++total;
+            }
+        }
+        if (total > 0) {
+            throw new ValidationException(
+                "%d SpotBugs violations (see log above)",
+                total
+            );
+        }
+    }
+}

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/SpotBugsValidator.java
@@ -29,34 +29,20 @@
  */
 package com.qulice.spotbugs;
 
-import com.jcabi.log.Logger;
 import com.qulice.spi.Environment;
 import com.qulice.spi.ValidationException;
 import com.qulice.spi.Validator;
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * Validates source code and compiled binaries with SpotBugs.
  *
  * @since 0.19
  */
-@SuppressWarnings({"PMD.ExcessiveImports", "PMD.AvoidDuplicateLiterals"})
 public final class SpotBugsValidator implements Validator {
 
     @Override
     public void validate(final Environment env) throws ValidationException {
-        if (env.outdir().exists()) {
-            if (!env.exclude("spotbugs", "")) {
-                this.check(SpotBugsValidator.spotbugs(env));
-            }
-        } else {
-            Logger.info(
-                this,
-                "No classes at %s, no SpotBugs validation",
-                env.outdir()
-            );
-        }
+        throw new UnsupportedOperationException("validate not implemented");
     }
 
     @Override
@@ -64,43 +50,4 @@ public final class SpotBugsValidator implements Validator {
         return "SpotBugs";
     }
 
-    /**
-     * Start spotbugs and return its output.
-     * @param env Environment
-     * @return Output of spotbugs
-     */
-    @SuppressWarnings("PMD.AvoidDuplicateLiterals")
-    private static String spotbugs(final Environment env) {
-        throw new UnsupportedOperationException("spotbugs not implemented");
-    }
-
-    /**
-     * Java options.
-     * @return Options
-     */
-    private static Collection<String> options() {
-        return new LinkedList<>();
-    }
-
-    /**
-     * Check report for errors.
-     * @param report The report
-     * @throws ValidationException If it contains errors
-     */
-    private void check(final String report) throws ValidationException {
-        int total = 0;
-        for (final String line
-            : report.split(System.getProperty("line.separator"))) {
-            if (line.matches("[a-zA-Z ]+: .*")) {
-                Logger.warn(this, "SpotBugs: %s", line);
-                ++total;
-            }
-        }
-        if (total > 0) {
-            throw new ValidationException(
-                "%d SpotBugs violations (see log above)",
-                total
-            );
-        }
-    }
 }

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * SpotBugs validator.
+ *
+ * @since 0.17
+ */
+package com.qulice.spotbugs;

--- a/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
+++ b/qulice-spotbugs/src/main/java/com/qulice/spotbugs/package-info.java
@@ -31,6 +31,6 @@
 /**
  * SpotBugs validator.
  *
- * @since 0.17
+ * @since 0.19
  */
 package com.qulice.spotbugs;

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 
 /**
  * Test case for {@link SpotBugsValidator}.
- * @since 0.3
+ * @since 0.19
  * @todo #884:30min Continue migration from FindBugs to SpotBugs. Implement
  *  SpotBugsValidator for this and then uncomment SpotBugsValidatorTest class
  *  so the minimal tests on this class can be run. Then, after all is set,

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.spotbugs;
+
+import com.qulice.spi.Environment;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test case for {@link SpotBugsValidator}.
+ * @since 0.3
+ * @todo #884:30min Continue migration from FindBugs to SpotBugs. Implement
+ *  SpotBugsValidator for this and then uncomment SpotBugsValidatorTest class
+ *  so the minimal tests on this class can be run. Then, after all is set,
+ *  remove FindBugs references from pom and from qulice executions.
+ */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@Ignore
+public final class SpotBugsValidatorTest {
+
+    /**
+     * SpotBugsValidatorTest can pass correct files with no exceptions.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void passesCorrectFilesWithNoExceptions() throws Exception {
+        final Environment env = new Environment.Mock()
+            .withFile("src/main/java/Main.java", "class Main { int x = 0; }")
+            .withDefaultClasspath();
+        new SpotBugsValidator().validate(env);
+    }
+
+    /**
+     * SpotBugs can exclude classes from check.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void excludesIncorrectClassFormCheck() throws Exception {
+        final Environment env = new Environment.Mock()
+            .withFile(
+                "target/classes/Foo.class",
+                "class Foo { public Foo clone() { return this; } }"
+            ).withExcludes("Foo").withDefaultClasspath();
+        new SpotBugsValidator().validate(env);
+    }
+
+    /**
+     * FindbugsValidator can exclude several classes from check.
+     * @throws Exception If something wrong happens inside
+     */
+    @Test
+    public void excludesSeveralIncorrectClassFromCheck() throws Exception {
+        final Environment env = new Environment.Mock()
+            .withFile(
+                "target/classes/Foo.java",
+                "class Foo { public Foo clone() { return this; } }"
+            ).withFile(
+                "target/classes/Bar.java",
+                "class Bar { public Bar clone() { return this; } }"
+            ).withExcludes("Foo,Bar")
+            .withDefaultClasspath();
+        new SpotBugsValidator().validate(env);
+    }
+}

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Tests of SpotBugs validator.
+ *
+ * @since 0.3
+ */
+package com.qulice.spotbugs;

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/package-info.java
@@ -31,6 +31,6 @@
 /**
  * Tests of SpotBugs validator.
  *
- * @since 0.3
+ * @since 0.19
  */
 package com.qulice.spotbugs;


### PR DESCRIPTION
For #884:
- Added dependencies and `SpotBugsValidation` skeleton `SpotBug` checks
- Added `SpotBugsValidationTests` which tests basic `SpotBugsValidator` behavior
- Added puzzle for resuming implementation