### PR TITLE
#963 removed another rule

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -41,6 +41,8 @@
 
     <rule ref="category/java/bestpractices.xml">
         <exclude name="JUnitTestsShouldIncludeAssert"/>
+        <exclude name="PositionLiteralsFirstInComparisons"/>
+        <exclude name="PositionLiteralsFirstInCaseInsensitiveComparisons"/>
     </rule>
     <rule ref="category/java/codestyle.xml">
         <exclude name="AtLeastOneConstructor"/>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
@@ -69,6 +69,7 @@ public final class PmdDisabledRulesTest {
                 {"AvoidUsingVolatile"},
                 {"DefaultPackage"},
                 {"ExcessiveImports"},
+                {"PositionLiteralsFirstInComparisons"},
             }
         );
     }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/PositionLiteralsFirstInComparisons.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/PositionLiteralsFirstInComparisons.java
@@ -1,0 +1,9 @@
+package foo;
+
+
+public final class PositionLiteralsFirstInComparisons {
+
+    public boolean method(String other) {
+        return other.equals("True");
+    }
+}


### PR DESCRIPTION
#963
* PMD added another rule that we will remove for now: PositionLiteralsFirstInComparisons and PositionLiteralsFirstInCaseInsensitiveComparisons