### PR TITLE
#963 remove requirement for serial version UID

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -68,6 +68,7 @@
         <exclude name="DataflowAnomalyAnalysis"/>
         <exclude name="AvoidLiteralsInIfCondition"/>
         <exclude name="BeanMembersShouldSerialize"/>
+        <exclude name="MissingSerialVersionUID"/>
     </rule>
     <rule ref="category/java/performance.xml">
         <exclude name="AvoidInstantiatingObjectsInLoops"/>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdDisabledRulesTest.java
@@ -70,6 +70,7 @@ public final class PmdDisabledRulesTest {
                 {"DefaultPackage"},
                 {"ExcessiveImports"},
                 {"PositionLiteralsFirstInComparisons"},
+                {"MissingSerialVersionUID"},
             }
         );
     }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/MissingSerialVersionUID.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/MissingSerialVersionUID.java
@@ -1,0 +1,8 @@
+package foo;
+
+public final class MissingSerialVersionUID extends Exception {
+
+    public boolean method(String other) {
+        return other.equals("True");
+    }
+}


### PR DESCRIPTION
#963 
* disabled requirement for serialVersionUID (not many projects need serializable, but many extend from Exceptions)