### PR TITLE
#972 removed linguisting naming

### DIFF
--- a/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
+++ b/qulice-pmd/src/main/resources/com/qulice/pmd/ruleset.xml
@@ -53,6 +53,7 @@
         <exclude name="ClassNamingConventions"/>
         <exclude name="CommentDefaultAccessModifier"/>
         <exclude name="DefaultPackage"/>
+        <exclude name="LinguisticNaming"/>
     </rule>
     <rule ref="category/java/design.xml">
         <exclude name="LoosePackageCoupling"/>


### PR DESCRIPTION
#972 
* removed LinguisticNaming - it doesn't fit our style, and causes problems in case of overriding (see https://github.com/pmd/pmd/issues/1543)