### PR TITLE
For #887: Ignore lambdas on constructors.

### DIFF
--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdValidatorTest.java
@@ -39,6 +39,8 @@ import java.util.Collection;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.hamcrest.core.IsEqual;
+import org.hamcrest.core.IsNot;
 import org.junit.Test;
 
 /**
@@ -306,6 +308,24 @@ public final class PmdValidatorTest {
             file, Matchers.is(false),
             RegexMatchers.containsPattern(
                 String.format(PmdValidatorTest.CODE_IN_CON, file)
+            )
+        ).validate();
+    }
+
+    /**
+     * PmdValidator allows lambda in constructor.
+     * @throws Exception If something wrong happens inside.
+     */
+    @Test
+    public void allowsLambdaInConstructor()
+        throws Exception {
+        final String file = "LambdaInConstructor.java";
+        new PmdAssert(
+            file, new IsEqual<>(true),
+            new IsNot<>(
+                RegexMatchers.containsPattern(
+                    String.format(PmdValidatorTest.CODE_IN_CON, file)
+                )
             )
         ).validate();
     }

--- a/qulice-pmd/src/test/resources/com/qulice/pmd/LambdaInConstructor.java
+++ b/qulice-pmd/src/test/resources/com/qulice/pmd/LambdaInConstructor.java
@@ -1,0 +1,30 @@
+package foo;
+
+public final class LambdaInConstructor {
+    private final transient int number;
+    private final transient int another;
+
+    public LambdaInConstructor(final int parameter) {
+        this(
+            parameter,
+             () -> {
+                final int ret;
+                if (parameter % 2 == 0){
+                    ret = 10;
+                } else {
+                    ret = 20;
+                }
+                return ret;
+             }
+        );
+    }
+
+    public LambdaInConstructor(final int parameter, final int other) {
+        this.number = parameter;
+        this.another = other;
+    }
+
+    public int num() {
+        return number + another;
+    }
+}


### PR DESCRIPTION
For #887: Ignore lambdas on constructors.
- Created test assuring that `PMD` is ignoring lambda in constructors