### PR TITLE
For #847: Enforce parameter order in javadoc

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2011-2018, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle;
+
+import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
+
+/**
+ * Checks method parameters order to comply with what is defined in method
+ * javadoc.
+ *
+ * @since 0.18.10
+ * @todo #847:30min Enforce right parameter order in javadoc. Checkstyle must
+ *  check if parameter order in javadoc is the same as is in the method
+ *  signature. Implement this check and add its tests to checks.xml under
+ *  custom checks.
+ */
+public final class JavadocParameterOrderCheck extends AbstractCheck {
+    @Override
+    public int[] getDefaultTokens() {
+        throw new UnsupportedOperationException(
+            "getDefaultTokens() not implemented"
+        );
+    }
+
+    @Override
+    public int[] getAcceptableTokens() {
+        throw new UnsupportedOperationException(
+            "getAcceptableTokens() not implemented"
+        );
+    }
+
+    @Override
+    public int[] getRequiredTokens() {
+        throw new UnsupportedOperationException(
+            "getRequiredTokens() not implemented"
+        );
+    }
+}

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2018, Qulice.com
+ * Copyright (c) 2011-2019, Qulice.com
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Invalid.java
@@ -1,0 +1,21 @@
+/*
+ * Empty javadoc line at the beginning.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public final class Invalid {
+
+    /**
+     * Javadoc with parameters in different order than the method signature.
+     * @param bparam - param b.
+     * @param aparam - param a.
+     * @return Param.
+     */
+    public String method(final String aparam, final String bparam) {
+        return bparam + aparam;
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Valid.java
@@ -1,0 +1,21 @@
+/*
+ * Empty javadoc line at the beginning.
+ */
+package com.qulice.checkstyle;
+
+/**
+ * This is not a real Java class. It won't be compiled ever. It is used
+ * only as a text resource in integration.ChecksIT.
+ */
+public final class Invalid {
+
+    /**
+     * Javadoc with parameters in same order than the method signature.
+     * @param bparam - param b.
+     * @param aparam - param a.
+     * @return Param.
+     */
+    public String method(final String bparam, final String aparam) {
+        return bparam + aparam;
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/config.xml
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/config.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!--
+ * This is not a real Checkstyle config. It is used
+ * only as a text resource in integration.ChecksIT.
+ -->
+<module name="Checker">
+    <module name="TreeWalker">
+        <module name="com.qulice.checkstyle.JavadocParameterOrderCheck"/>
+    </module>
+</module>

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/violations.txt
@@ -1,0 +1,1 @@
+18:Javadoc parameter order different than method signature


### PR DESCRIPTION
For #847: Enforce parameter order in javadoc
- Added test for parameter order check
- Left puzzle to complete check implementation