### PR TITLE
For #743: Nested classes should have since tag

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -66,7 +66,7 @@ import org.apache.commons.lang3.StringUtils;
  * @todo #743:30min Nested classes should have since tag. Implement check to
  *  validate if nested classes javadoc have a valid since tag. After the
  *  implementation add JavadocTagsCheck to checks.xml and ChecksTest (removed
- *   because now the test fails).
+ *  because now the test fails).
  */
 public final class JavadocTagsCheck extends AbstractCheck {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocTagsCheck.java
@@ -63,6 +63,10 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @see <a href="http://svnbook.red-bean.com/en/1.4/svn.advanced.props.special.keywords.html">Keywords substitution in Subversion</a>
  * @since 0.3
+ * @todo #743:30min Nested classes should have since tag. Implement check to
+ *  validate if nested classes javadoc have a valid since tag. After the
+ *  implementation add JavadocTagsCheck to checks.xml and ChecksTest (removed
+ *   because now the test fails).
  */
 public final class JavadocTagsCheck extends AbstractCheck {
 

--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -404,7 +404,6 @@
         <module name="com.qulice.checkstyle.BracketsStructureCheck"/>
         <module name="com.qulice.checkstyle.CurlyBracketsStructureCheck"/>
         <module name="com.qulice.checkstyle.EmptyLinesCheck"/>
-        <module name="com.qulice.checkstyle.JavadocTagsCheck"/>
         <module name="com.qulice.checkstyle.StringLiteralsConcatenationCheck"/>
         <module name="com.qulice.checkstyle.MultilineJavadocTagsCheck"/>
         <module name="com.qulice.checkstyle.NoJavadocForOverriddenMethodsCheck"/>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -68,7 +68,6 @@ public final class ChecksTest {
         "StringLiteralsConcatenationCheck",
         "EmptyLinesCheck",
         "ImportCohesionCheck",
-        "JavadocTagsCheck",
         "BracketsStructureCheck",
         "CurlyBracketsStructureCheck",
         "JavadocLocationCheck",

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Invalid.java
@@ -16,3 +16,15 @@ public final class ProhibitedTagsAndMissingSince {
  */
 public final class InvalidSince {
 }
+
+/**
+ * This class have an inner class with no since tag.
+ * @since 1.0
+ */
+public final class InvalidInner {
+    /**
+     * Inner class without since tag.
+     */
+    public final class InvalidInnerSince {
+    }
+}

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/Valid.java
@@ -6,7 +6,17 @@
 /**
  * @since 0.28.3
  */
-public final class Invalid {
+public final class Valid {
     public void main() {
+    }
+
+    /**
+     * Inner.
+     *
+     * @since 3.14
+    */
+    private final static class Inner {
+        public void other() {
+        }
     }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocTagsCheck/violations.txt
@@ -1,1 +1,2 @@
 6:Missing '@since' tag in class/interface comment
+25:Missing '@since' tag in class/interface comment


### PR DESCRIPTION
For #743: Nested classes should have since tag
- Changed `JavadocTagsCheck` tests so it does not pass when `since` tag is absent in nested class
- Removed `JavadocTagsCheck` test execution; the test fails now
- Added puzzle for `JavadocTagsCheck` correction and re-activation of tests