### PR TITLE
For #966 Update jcabi parent to 0.49.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.jcabi</groupId>
         <artifactId>parent</artifactId>
-        <version>0.40</version>
+        <version>0.49.3</version>
     </parent>
     <groupId>com.qulice</groupId>
     <artifactId>qulice</artifactId>

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -45,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -168,7 +169,7 @@ public final class CheckstyleValidator implements ResourceValidator {
         final URL url = CheckstyleValidator.toUrl(env, name);
         final String content;
         try {
-            content = IOUtils.toString(url.openStream())
+            content = IOUtils.toString(url.openStream(), Charset.defaultCharset())
                 .trim().replaceAll("[\\r\\n]+$", "");
         } catch (final IOException ex) {
             throw new IllegalStateException("Failed to read license", ex);

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -45,13 +45,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.cactoos.text.ReplacedText;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.TrimmedText;
 import org.xml.sax.InputSource;
 
 /**
@@ -169,10 +170,15 @@ public final class CheckstyleValidator implements ResourceValidator {
         final URL url = CheckstyleValidator.toUrl(env, name);
         final String content;
         try {
-            content = IOUtils.toString(
-                url.openStream(),
-                Charset.defaultCharset()
-            ).trim().replaceAll("[\\r\\n]+$", "");
+            content = new ReplacedText(
+                new TrimmedText(
+                    new TextOf(
+                        url.openStream()
+                    )
+                ),
+                "[\\r\\n]+$",
+                ""
+            ).asString();
         } catch (final IOException ex) {
             throw new IllegalStateException("Failed to read license", ex);
         }

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -169,8 +169,10 @@ public final class CheckstyleValidator implements ResourceValidator {
         final URL url = CheckstyleValidator.toUrl(env, name);
         final String content;
         try {
-            content = IOUtils.toString(url.openStream(), Charset.defaultCharset())
-                .trim().replaceAll("[\\r\\n]+$", "");
+            content = IOUtils.toString(
+                url.openStream(),
+                Charset.defaultCharset()
+            ).trim().replaceAll("[\\r\\n]+$", "");
         } catch (final IOException ex) {
             throw new IllegalStateException("Failed to read license", ex);
         }

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -35,6 +35,7 @@ import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -123,7 +124,8 @@ public final class ChecksTest {
             IOUtils.toString(
                 this.getClass().getResourceAsStream(
                     String.format("%s/violations.txt", this.dir)
-                )
+                ),
+                Charset.defaultCharset()
             ),
             "\n"
         );

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.PropertiesExpander;
 import com.puppycrawl.tools.checkstyle.api.AuditEvent;
 import com.puppycrawl.tools.checkstyle.api.AuditListener;
 import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -125,7 +125,7 @@ public final class ChecksTest {
                 this.getClass().getResourceAsStream(
                     String.format("%s/violations.txt", this.dir)
                 ),
-                Charset.defaultCharset()
+                StandardCharsets.UTF_8
             ),
             "\n"
         );

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -35,11 +35,12 @@ import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.Collection;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
+import org.cactoos.text.FormattedText;
+import org.cactoos.text.JoinedText;
+import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -55,6 +56,8 @@ import org.junit.Test;
  * @todo #412:30min Split this class into smaller ones and remove PMD
  *  exclude `TooManyMethods`. Good candidates for moving out of this class
  *  are all that use `validateCheckstyle` method.
+ * @checkstyle ClassDataAbstractionCoupling (800 lines)
+ *  Can also be removed after splitting up this class into smaller ones.
  */
 @SuppressWarnings(
     {
@@ -633,10 +636,11 @@ public final class CheckstyleValidatorTest {
             file, false
         );
         final String name = "AbbreviationAsWordInNameCheck";
-        final String message = StringUtils.join(
-            "Abbreviation in name '%s' ",
+        final String message = new JoinedText(
+            " ",
+            "Abbreviation in name '%s'",
             "must contain no more than '2' consecutive capital letters."
-        );
+        ).asString();
         MatcherAssert.assertThat(
             results,
             Matchers.hasItems(
@@ -773,10 +777,11 @@ public final class CheckstyleValidatorTest {
         )
             .withFile(
                 String.format("src/main/java/foo/%s", file),
-                IOUtils.toString(
-                    this.getClass().getResourceAsStream(file),
-                    Charset.defaultCharset()
-                )
+                new TextOf(
+                    new ResourceOf(
+                        new FormattedText("com/qulice/checkstyle/%s", file)
+                    )
+                ).asString()
             );
         final Collection<Violation> results =
             new CheckstyleValidator(env).validate(

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -35,6 +35,7 @@ import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -773,7 +774,8 @@ public final class CheckstyleValidatorTest {
             .withFile(
                 String.format("src/main/java/foo/%s", file),
                 IOUtils.toString(
-                    this.getClass().getResourceAsStream(file)
+                    this.getClass().getResourceAsStream(file),
+                    Charset.defaultCharset()
                 )
             );
         final Collection<Violation> results =

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -32,7 +32,7 @@ package com.qulice.checkstyle;
 import com.jcabi.aspects.Tv;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
 import org.cactoos.text.JoinedText;
 import org.junit.rules.TestRule;
@@ -123,7 +123,7 @@ public final class LicenseRule implements TestRule {
         FileUtils.writeStringToFile(
             license,
             new JoinedText(this.eol, this.lines).asString(),
-            Charset.defaultCharset()
+            StandardCharsets.UTF_8
         );
         if (this.directory != null) {
             this.makePackageInfo(this.directory);
@@ -157,7 +157,7 @@ public final class LicenseRule implements TestRule {
         FileUtils.writeStringToFile(
             info,
             body.toString(),
-            Charset.defaultCharset()
+            StandardCharsets.UTF_8
         );
     }
 

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -32,6 +32,7 @@ package com.qulice.checkstyle;
 import com.jcabi.aspects.Tv;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.rules.TestRule;
@@ -121,7 +122,8 @@ public final class LicenseRule implements TestRule {
         FileUtils.forceDeleteOnExit(license);
         FileUtils.writeStringToFile(
             license,
-            StringUtils.join(this.lines, this.eol)
+            StringUtils.join(this.lines, this.eol),
+            Charset.defaultCharset()
         );
         if (this.directory != null) {
             this.makePackageInfo(this.directory);
@@ -152,7 +154,11 @@ public final class LicenseRule implements TestRule {
             .append(" */").append(this.eol)
             .append("package ").append(this.pkg)
             .append(';').append(this.eol);
-        FileUtils.writeStringToFile(info, body.toString());
+        FileUtils.writeStringToFile(
+            info,
+            body.toString(),
+            Charset.defaultCharset()
+        );
     }
 
 }

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -34,7 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.cactoos.text.JoinedText;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -122,7 +122,7 @@ public final class LicenseRule implements TestRule {
         FileUtils.forceDeleteOnExit(license);
         FileUtils.writeStringToFile(
             license,
-            StringUtils.join(this.lines, this.eol),
+            new JoinedText(this.eol, this.lines).asString(),
             Charset.defaultCharset()
         );
         if (this.directory != null) {

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -167,7 +168,8 @@ public final class FindBugsValidator implements Validator {
         try {
             FileUtils.writeStringToFile(
                 new File(path),
-                FindBugsValidator.generateExcludes(excludes)
+                FindBugsValidator.generateExcludes(excludes),
+                Charset.defaultCharset()
             );
         } catch (final IOException exc) {
             throw new IllegalStateException(

--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
@@ -44,7 +44,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -169,7 +168,7 @@ public final class FindBugsValidator implements Validator {
             FileUtils.writeStringToFile(
                 new File(path),
                 FindBugsValidator.generateExcludes(excludes),
-                Charset.defaultCharset()
+                StandardCharsets.UTF_8
             );
         } catch (final IOException exc) {
             throw new IllegalStateException(

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
@@ -33,7 +33,7 @@ import com.google.common.io.Files;
 import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -70,7 +70,7 @@ public final class BytecodeMocker {
         FileUtils.writeStringToFile(
             input,
             this.source,
-            Charset.defaultCharset()
+            StandardCharsets.UTF_8
         );
         final ProcessBuilder builder = new ProcessBuilder(
             "javac",
@@ -92,7 +92,7 @@ public final class BytecodeMocker {
                     "Failed to compile '%s':%n%s", this.source,
                     IOUtils.toString(
                         process.getErrorStream(),
-                        Charset.defaultCharset()
+                        StandardCharsets.UTF_8
                     )
                 )
             );

--- a/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
+++ b/qulice-findbugs/src/mock/java/com/qulice/findbugs/BytecodeMocker.java
@@ -33,6 +33,7 @@ import com.google.common.io.Files;
 import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -66,7 +67,11 @@ public final class BytecodeMocker {
     public byte[] mock() throws IOException {
         final File outdir = Files.createTempDir();
         final File input = File.createTempFile("input", ".java");
-        FileUtils.writeStringToFile(input, this.source);
+        FileUtils.writeStringToFile(
+            input,
+            this.source,
+            Charset.defaultCharset()
+        );
         final ProcessBuilder builder = new ProcessBuilder(
             "javac",
             "-d",
@@ -85,7 +90,10 @@ public final class BytecodeMocker {
             throw new IllegalStateException(
                 String.format(
                     "Failed to compile '%s':%n%s", this.source,
-                    IOUtils.toString(process.getErrorStream())
+                    IOUtils.toString(
+                        process.getErrorStream(),
+                        Charset.defaultCharset()
+                    )
                 )
             );
         }

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -116,8 +116,8 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -116,10 +116,6 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.jcabi</groupId>
             <artifactId>jcabi-log</artifactId>
         </dependency>

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -47,6 +47,11 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.cactoos</groupId>
+            <artifactId>cactoos</artifactId>
+            <version>0.38</version>
+        </dependency>
+        <dependency>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-spi</artifactId>
             <version>${project.version}</version>
@@ -114,6 +119,11 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.jcabi</groupId>

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -36,7 +36,6 @@ import com.qulice.spi.ValidationException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 
 /**

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/PomXpathValidator.java
@@ -35,6 +35,7 @@ import com.qulice.spi.Environment;
 import com.qulice.spi.ValidationException;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 
@@ -93,7 +94,7 @@ public final class PomXpathValidator implements MavenValidator {
                             "pom.xml"
                         )
                     ),
-                    Charsets.UTF_8
+                    StandardCharsets.UTF_8
                 )
             ).registerNs("pom", "http://maven.apache.org/POM/4.0.0");
         } catch (final IOException exc) {

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
@@ -32,6 +32,7 @@ package com.qulice.maven;
 import com.jcabi.log.Logger;
 import com.qulice.spi.ValidationException;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -175,7 +176,10 @@ public final class SvnPropertiesValidator implements MavenValidator {
         try {
             final Process process = builder.start();
             process.waitFor();
-            return IOUtils.toString(process.getInputStream()).trim();
+            return IOUtils.toString(
+                process.getInputStream(),
+                Charset.defaultCharset()
+            ).trim();
         } catch (final java.io.IOException ex) {
             throw new IllegalArgumentException(ex);
         } catch (final InterruptedException ex) {

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
@@ -32,11 +32,12 @@ package com.qulice.maven;
 import com.jcabi.log.Logger;
 import com.qulice.spi.ValidationException;
 import java.io.File;
-import java.nio.charset.Charset;
 import java.util.Collection;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.maven.project.MavenProject;
+import org.cactoos.text.TextOf;
+import org.cactoos.text.TrimmedText;
+import org.cactoos.text.UncheckedText;
 
 /**
  * Check for required svn properties in all text files.
@@ -176,10 +177,13 @@ public final class SvnPropertiesValidator implements MavenValidator {
         try {
             final Process process = builder.start();
             process.waitFor();
-            return IOUtils.toString(
-                process.getInputStream(),
-                Charset.defaultCharset()
-            ).trim();
+            return new UncheckedText(
+                new TrimmedText(
+                    new TextOf(
+                        process.getInputStream()
+                    )
+                )
+            ).asString();
         } catch (final java.io.IOException ex) {
             throw new IllegalArgumentException(ex);
         } catch (final InterruptedException ex) {

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
@@ -32,7 +32,6 @@ package com.qulice.maven;
 import com.qulice.spi.Environment;
 import com.qulice.spi.ResourceValidator;
 import com.qulice.spi.Validator;
-import java.io.File;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.context.Context;

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/CheckMojoTest.java
@@ -89,7 +89,7 @@ public final class CheckMojoTest {
         Mockito.verify(internal).validate(Mockito.any(MavenEnvironment.class));
         Mockito.verify(external).validate(Mockito.any(Environment.class));
         Mockito.verify(rexternal, Mockito.atLeastOnce())
-            .validate(Mockito.anyCollectionOf(File.class));
+            .validate(Mockito.anyCollection());
     }
 
 }

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
@@ -33,7 +33,8 @@ import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
+import org.cactoos.io.ResourceOf;
+import org.cactoos.text.TextOf;
 import org.junit.Test;
 
 /**
@@ -55,10 +56,9 @@ public final class PomXpathValidatorTest {
                 "/pom:project/pom:dependencies/pom:dependency[pom:artifactId='commons-io']/pom:version[.='1.2.5']/text()"
             )
         ).mock();
-        final String pom = IOUtils.toString(
-            this.getClass().getResourceAsStream("PomXpathValidator/pom.xml"),
-            Charset.defaultCharset()
-        );
+        final String pom = new TextOf(
+            new ResourceOf("com/qulice/maven/PomXpathValidator/pom.xml")
+        ).asString();
         FileUtils.write(
             new File(
                 String.format(

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
@@ -30,6 +30,7 @@
 package com.qulice.maven;
 
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -55,7 +56,8 @@ public final class PomXpathValidatorTest {
             )
         ).mock();
         final String pom = IOUtils.toString(
-            this.getClass().getResourceAsStream("PomXpathValidator/pom.xml")
+            this.getClass().getResourceAsStream("PomXpathValidator/pom.xml"),
+            Charset.defaultCharset()
         );
         FileUtils.write(
             new File(
@@ -63,7 +65,8 @@ public final class PomXpathValidatorTest {
                     "%s%spom.xml", env.basedir(), File.separator
                 )
             ),
-            pom
+            pom,
+            Charset.defaultCharset()
         );
         new PomXpathValidator().validate(env);
     }

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/PomXpathValidatorTest.java
@@ -30,7 +30,7 @@
 package com.qulice.maven;
 
 import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import org.apache.commons.io.FileUtils;
 import org.cactoos.io.ResourceOf;
@@ -66,7 +66,7 @@ public final class PomXpathValidatorTest {
                 )
             ),
             pom,
-            Charset.defaultCharset()
+            StandardCharsets.UTF_8
         );
         new PomXpathValidator().validate(env);
     }

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -32,7 +32,7 @@ package com.qulice.pmd;
 import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import org.apache.commons.io.IOUtils;
@@ -85,7 +85,7 @@ final class PmdAssert {
             name,
             IOUtils.toString(
                 this.getClass().getResourceAsStream(this.file),
-                Charset.defaultCharset()
+                StandardCharsets.UTF_8
             )
         );
         final Collection<Violation> violations = new PmdValidator(env).validate(

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -75,6 +75,8 @@ final class PmdAssert {
     /**
      * Validated given file against PMD.
      * @throws Exception In case of error.
+     * @todo #966:5min Add Cactoos dependency to qulice-pmd and replace IOUtils
+     *  usage with Cactoos alternatives `TextOf` and `ResourceOf`
      */
     public void validate() throws Exception {
         final Environment.Mock mock = new Environment.Mock();

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -32,6 +32,7 @@ package com.qulice.pmd;
 import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
+import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
 import org.apache.commons.io.IOUtils;
@@ -81,7 +82,8 @@ final class PmdAssert {
         final Environment env = mock.withFile(
             name,
             IOUtils.toString(
-                this.getClass().getResourceAsStream(this.file)
+                this.getClass().getResourceAsStream(this.file),
+                Charset.defaultCharset()
             )
         );
         final Collection<Violation> violations = new PmdValidator(env).validate(

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -31,7 +31,7 @@ package com.qulice.spi;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -195,7 +195,7 @@ public interface Environment {
             FileUtils.writeStringToFile(
                 file,
                 content,
-                Charset.defaultCharset()
+                StandardCharsets.UTF_8
             );
             return this;
         }

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -192,7 +192,11 @@ public interface Environment {
         public Environment.Mock withFile(final String name,
             final String content) throws IOException {
             final File file = new File(this.basedir, name);
-            FileUtils.writeStringToFile(file, content, Charset.defaultCharset());
+            FileUtils.writeStringToFile(
+                file,
+                content,
+                Charset.defaultCharset()
+            );
             return this;
         }
 

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -31,6 +31,7 @@ package com.qulice.spi;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -191,7 +192,7 @@ public interface Environment {
         public Environment.Mock withFile(final String name,
             final String content) throws IOException {
             final File file = new File(this.basedir, name);
-            FileUtils.writeStringToFile(file, content);
+            FileUtils.writeStringToFile(file, content, Charset.defaultCharset());
             return this;
         }
 


### PR DESCRIPTION
This update brought several problems, which failed the build.
They have all been resolved in this commit.

Release 0.48.5 brought a change to commons-collections,
this has been altered in the pom.xml.

Several IO methods have been deprecated. They implicitly
used `Charset.defaultCharset()`, so to keep it functionally
the same as before this change, I've made these usages
explicitly.

`StandardCharsets.UTF_8` is now the standard for JDK8+.

`Mockito.anyCollectionOf(File.class)` has been deprecated,
because since JDK8 `Mockito.anyCollection()` already deals
correctly with casting.