### PR TITLE
For #897: Test for RegexpSingleline behavior change

### DIFF
--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -675,6 +675,22 @@ public final class CheckstyleValidatorTest {
     }
 
     /**
+     * CheckstyleValidator can allow final static fields and overrides
+     * to have uppercase abbreviations.
+     *
+     * @throws Exception In case of error
+     * @todo #897:30min Allow lambdas and generics to be places at end of line.
+     *  RegexpSingleline is too strict and not allow generics and lambdas
+     *  being placed at end of lines. Correct this behavior and uncomment test
+     *  below.
+     */
+    @Ignore
+    @Test
+    public void checkLambdaAndGenericsAtEndOfLine() throws Exception {
+        this.runValidation("ValidLambdaAndGenericsAtEndOfLine.java", true);
+    }
+
+    /**
      * CheckstyleValidator can reject non diamond operator usage.
      * @throws Exception If error
      */

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
@@ -1,0 +1,30 @@
+/*
+ * Hello.
+ */
+package foo;
+
+/**
+ * Simple.
+ * @since 1.0
+ */
+public final class ValidLambda {
+
+    /**
+     * Final.
+     */
+    private final int zero = 0;
+
+    /**
+     * Main method.
+     */
+    public void main() {
+        final Proc proc = () ->
+            this.zero;
+        final Func func = var ->
+            var * 2;
+        final BiFunc bifunc = (param, par) ->
+            param * par;
+        final List<Integer>
+            list = new ArrayList<>();
+    }
+}


### PR DESCRIPTION
For #897:
- Added test for `RegexpSingleline` to accept `>` as last line character when in lambda arrows or generics
- Added todo for implementing the correct behavior and removing ignore from test