### PR TITLE
For #917: Make ProtectedMethodInFinalClassCheck stricter.

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
@@ -37,11 +37,16 @@ import com.puppycrawl.tools.checkstyle.utils.AnnotationUtil;
 import java.util.List;
 
 /**
- * Checks that final class doesn't contain protected methods.
- *
- * <p>If your method contain protected methods than it can't be final
+ * Checks that final class doesn't contain protected methods unless they are
+ * overriding protected methods from superclass.
  *
  * @since 0.6
+ * @todo #917:30min Make ProtectedMethodInFinalClassCheck stricter.
+ *  ProtectedMethodInFinalClassCheck must check if the protected method in final
+ *  class isn't overriding some default method from abstract parent class and
+ *  fail if so. The Invalid class for tests is already implemented and the
+ *  error message is commented in violations.txt. Uncomment it after the
+ *  implementation.
  */
 public final class ProtectedMethodInFinalClassCheck extends AbstractCheck {
 

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProtectedMethodInFinalClassCheck.java
@@ -44,9 +44,10 @@ import java.util.List;
  * @todo #917:30min Make ProtectedMethodInFinalClassCheck stricter.
  *  ProtectedMethodInFinalClassCheck must check if the protected method in final
  *  class isn't overriding some default method from abstract parent class and
- *  fail if so. The Invalid class for tests is already implemented and the
- *  error message is commented in violations.txt. Uncomment it after the
- *  implementation.
+ *  fail if so. The Invalid class for tests is already implemented. After the
+ *  change in ProtectedMethodInFinalClassCheck complete the tests adding the
+ *  following line to violations.txt:
+ *  23:Protected method is overriding default scoped method
  */
 public final class ProtectedMethodInFinalClassCheck extends AbstractCheck {
 

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/Invalid.java
@@ -13,4 +13,15 @@ public final class Invalid {
     private static final class Bar {
        protected void valid() {}
     }
+
+    private abstract static class Foo {
+        void valid() {};
+    }
+
+    private final static class FooChild extends Invalid.Foo {
+        @Override
+        protected void valid() {
+            return;
+        }
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/violations.txt
@@ -1,4 +1,3 @@
 9:Final class should not contain protected methods
 11:Final class should not contain protected methods
 14:Final class should not contain protected methods
-#23:Protected method is overriding default scoped method

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/ProtectedMethodInFinalClassCheck/violations.txt
@@ -1,3 +1,4 @@
 9:Final class should not contain protected methods
 11:Final class should not contain protected methods
 14:Final class should not contain protected methods
+#23:Protected method is overriding default scoped method


### PR DESCRIPTION
For #917:
- Added condition to failure test: when a default method is overrided by a protected one in a final class checkstyle should complain
- Added puzzle for completion of the task