### PR TITLE
Allow findbugs exclusion with filter file xml.

### DIFF
--- a/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
+++ b/qulice-findbugs/src/main/java/com/qulice/findbugs/FindBugsValidator.java
@@ -73,10 +73,21 @@ import org.objectweb.asm.tree.ClassNode;
 @SuppressWarnings({"PMD.ExcessiveImports", "PMD.AvoidDuplicateLiterals"})
 public final class FindBugsValidator implements Validator {
 
+    /**
+     * Exclude whole classes classes by FQN class name.
+     */
+    public static final String EXCLUDE = "findbugs";
+
+    /**
+     * Exclude using findbugs-filter configuration.
+     * http://findbugs.sourceforge.net/manual/filter.html.
+     */
+    public static final String EXCLUDE_FILTER = "findbugs-filter";
+
     @Override
     public void validate(final Environment env) throws ValidationException {
         if (env.outdir().exists()) {
-            if (!env.exclude("findbugs", "")) {
+            if (!env.exclude(FindBugsValidator.EXCLUDE, "")) {
                 this.check(this.findbugs(env));
             }
         } else {
@@ -127,13 +138,17 @@ public final class FindBugsValidator implements Validator {
      */
     private static void populateExcludes(final List<String> args,
         final Environment env) {
-        final Collection<String> filter = env.excludes("findbugs-filter");
+        final Collection<String> filter = env.excludes(
+            FindBugsValidator.EXCLUDE_FILTER
+        );
         if (filter.size() > 1) {
             throw new IllegalStateException(
                 "Only one findbugs-filter file allowed"
             );
         }
-        final Collection<String> excludes = env.excludes("findbugs");
+        final Collection<String> excludes = env.excludes(
+            FindBugsValidator.EXCLUDE
+        );
         if (!filter.isEmpty() && !excludes.isEmpty()) {
             throw new IllegalStateException(
                 "You can't combine findbugs and findbugs-filter together"

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -69,6 +69,11 @@ public final class DependenciesValidatorTest {
     private static final String TYPE = "jar";
 
     /**
+     * Dependencies check.
+     */
+    private static final String DEPENDENCIES = "dependencies";
+
+    /**
      * DependencyValidator can pass on when no violations are found.
      * @throws Exception If something wrong happens inside
      */
@@ -153,7 +158,7 @@ public final class DependenciesValidatorTest {
         new DependenciesValidator().validate(
             new MavenEnvironment.Wrap(
                 new Environment.Mock().withExcludes(
-                    "dependencies",
+                    DependenciesValidatorTest.DEPENDENCIES,
                     Joiner.on(':').join(
                         artifact.getGroupId(), artifact.getArtifactId()
                     )
@@ -188,7 +193,7 @@ public final class DependenciesValidatorTest {
         new DependenciesValidator().validate(
             new MavenEnvironment.Wrap(
                 new Environment.Mock().withExcludes(
-                    "dependencies",
+                    DependenciesValidatorTest.DEPENDENCIES,
                     Joiner.on(':').join(
                         artifact.getGroupId(), artifact.getArtifactId()
                     )

--- a/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
+++ b/qulice-maven-plugin/src/test/java/com/qulice/maven/DependenciesValidatorTest.java
@@ -153,6 +153,7 @@ public final class DependenciesValidatorTest {
         new DependenciesValidator().validate(
             new MavenEnvironment.Wrap(
                 new Environment.Mock().withExcludes(
+                    "dependencies",
                     Joiner.on(':').join(
                         artifact.getGroupId(), artifact.getArtifactId()
                     )
@@ -187,6 +188,7 @@ public final class DependenciesValidatorTest {
         new DependenciesValidator().validate(
             new MavenEnvironment.Wrap(
                 new Environment.Mock().withExcludes(
+                    "dependencies",
                     Joiner.on(':').join(
                         artifact.getGroupId(), artifact.getArtifactId()
                     )

--- a/qulice-spi/src/main/java/com/qulice/spi/Environment.java
+++ b/qulice-spi/src/main/java/com/qulice/spi/Environment.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
@@ -140,7 +141,7 @@ public interface Environment {
         /**
          * Exclude patterns.
          */
-        private String excl;
+        private final Map<String, List<String>> excl;
 
         /**
          * Public ctor.
@@ -170,6 +171,7 @@ public interface Environment {
             this.classpath.add(
                 this.outdir().getAbsolutePath().replace(File.separatorChar, '/')
             );
+            this.excl = new HashMap<>();
         }
         /**
          * With this param and its value.
@@ -216,13 +218,19 @@ public interface Environment {
 
         /**
          * With exclude patterns.
+         * @param check Name of the checker
          * @param excludes Exclude patterns
          * @return This object
          */
-        public Environment.Mock withExcludes(final String excludes) {
-            this.excl = excludes;
+        public Environment.Mock withExcludes(final String check,
+            final String excludes) {
+            this.excl.put(
+                check,
+                Arrays.asList(excludes.split(","))
+            );
             return this;
         }
+
         /**
          * With default classpath.
          * @return This object
@@ -298,13 +306,8 @@ public interface Environment {
 
         @Override
         public Collection<String> excludes(final String checker) {
-            final Collection<String> exc;
-            if (this.excl == null) {
-                exc = Collections.emptyList();
-            } else {
-                exc = Arrays.asList(this.excl.split(","));
-            }
-            return exc;
+            return this.excl.getOrDefault(checker, Collections.emptyList());
         }
+
     }
 }

--- a/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
+++ b/qulice-spotbugs/src/test/java/com.qulice.spotbugs/SpotBugsValidatorTest.java
@@ -67,7 +67,7 @@ public final class SpotBugsValidatorTest {
             .withFile(
                 "target/classes/Foo.class",
                 "class Foo { public Foo clone() { return this; } }"
-            ).withExcludes("Foo").withDefaultClasspath();
+            ).withExcludes("any check", "Foo").withDefaultClasspath();
         new SpotBugsValidator().validate(env);
     }
 
@@ -84,7 +84,7 @@ public final class SpotBugsValidatorTest {
             ).withFile(
                 "target/classes/Bar.java",
                 "class Bar { public Bar clone() { return this; } }"
-            ).withExcludes("Foo,Bar")
+            ).withExcludes("not implemented", "Foo,Bar")
             .withDefaultClasspath();
         new SpotBugsValidator().validate(env);
     }


### PR DESCRIPTION
Currently findbugs allows to exclude the files only on per-class basis, using the syntax
`<exclude>findbugs:org.package.Class</exclude>`
There is no way to exclude a class for a specific rule, it's only possible to exclude a class for all the rules which is not great.
Another way is to exclude is using `@SupressFBWarning` annotation, however that brings an additional dependency which is [not an option](https://github.com/yegor256/cactoos/pull/1020#discussion_r249264296) for many projects.

This PR:
Allows specifying a standard [findbugs-filter file](http://findbugs.sourceforge.net/manual/filter.html) 
using `<exclude>findbugs-filter:filter-file.xml</exclude>`
