### PR TITLE
For #1005: Allow -> and <> at end of lines

### DIFF
--- a/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
+++ b/qulice-checkstyle/src/main/resources/com/qulice/checkstyle/checks.xml
@@ -171,7 +171,7 @@
         <property name="message" value="Use 'java.nio.charset.StandardCharsets' instead"/>
     </module>
     <module name="RegexpSingleline">
-        <property name="format" value="^(?! *(/\*\*|\*|/\*|//)).*[\.\-\+%/\*&lt;&gt;] *$"/>
+        <property name="format" value="^(?! *(/\*\*|\*|/\*|//)).*[\.\-\+%/\*&lt;&gt;](?&lt;!(-&gt;)|&lt;*[A-Za-z]&gt;) *$"/>
         <property name="fileExtensions" value="java"/>
         <property name="message" value="Line cannot end with this symbol, move it to the next line"/>
     </module>

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -684,12 +684,7 @@ public final class CheckstyleValidatorTest {
      * to have uppercase abbreviations.
      *
      * @throws Exception In case of error
-     * @todo #897:30min Allow lambdas and generics to be places at end of line.
-     *  RegexpSingleline is too strict and not allow generics and lambdas
-     *  being placed at end of lines. Correct this behavior and uncomment test
-     *  below.
      */
-    @Ignore
     @Test
     public void checkLambdaAndGenericsAtEndOfLine() throws Exception {
         this.runValidation("ValidLambdaAndGenericsAtEndOfLine.java", true);

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ValidLambdaAndGenericsAtEndOfLine.java
@@ -7,7 +7,7 @@ package foo;
  * Simple.
  * @since 1.0
  */
-public final class ValidLambda {
+public final class ValidLambdaAndGenericsAtEndOfLine {
 
     /**
      * Final.


### PR DESCRIPTION
For #1005:
- Changed regex in `checks.xml` allowing `->` and `<*>` at end of lines
- Removed `@Ignore` from test and todo
- Fixed sample class name
