### PR TITLE
For #1034: Fix IndexOutOfBoundsException in JavadocParameterOrderCheck

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/JavadocParameterOrderCheck.java
@@ -104,20 +104,7 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
         final FileContents contents = getFileContents();
         final TextBlock doc = contents.getJavadocBefore(ast.getLineNo());
         if (doc != null) {
-            final List<JavadocTag> tags = getMethodTags(doc);
-            final List<DetailAST> parameters = getParameters(ast);
-            for (int param = 0; param < parameters.size(); param = param + 1) {
-                if (!parameters.get(param).getText().equals(
-                    tags.get(param).getFirstArg()
-                    )
-                ) {
-                    this.log(
-                        tags.get(param).getLineNo(),
-                        // @checkstyle LineLength (1 line)
-                        "Javadoc parameter order different than method signature"
-                    );
-                }
-            }
+            this.checkParameters(ast, doc);
         }
     }
 
@@ -241,5 +228,35 @@ public final class JavadocParameterOrderCheck extends AbstractCheck {
             child = child.getNextSibling();
         }
         return value;
+    }
+
+    /**
+     * Checks method parameters order to comply with what is defined in method
+     * javadoc.
+     * @param ast The method node.
+     * @param doc Javadoc text block.
+     */
+    private void checkParameters(final DetailAST ast, final TextBlock doc) {
+        final List<JavadocTag> tags = getMethodTags(doc);
+        final List<DetailAST> parameters = getParameters(ast);
+        if (tags.size() == parameters.size()) {
+            for (int param = 0; param < parameters.size(); param = param + 1) {
+                final String parameter = parameters.get(param).getText();
+                final JavadocTag tag = tags.get(param);
+                if (!parameter.equals(tag.getFirstArg())) {
+                    this.log(
+                        tag.getLineNo(),
+                        // @checkstyle LineLength (1 line)
+                        "Javadoc parameter order different than method signature"
+                    );
+                }
+            }
+        } else {
+            this.log(
+                ast.getLineNo(),
+                // @checkstyle LineLength (1 line)
+                "Number of javadoc parameters different than method signature"
+            );
+        }
     }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Invalid.java
@@ -33,4 +33,22 @@ public final class Invalid {
     public String method(final String aparam, final String bparam) {
         return bparam + aparam;
     }
+
+    /**
+     * Javadoc with a different number of parameters than in the method
+     *  signature.
+     * @param eparam - param e.
+     * @return Param.
+     */
+    public String method2(final String cparam, final String dparam) {
+        return cparam + dparam;
+    }
+
+    /**
+     * Javadoc without parameters for a method with several parameters.
+     * @return Param.
+     */
+    public String method3(final String hparam) {
+        return hparam;
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/violations.txt
@@ -1,4 +1,6 @@
-19:Javadoc parameter order different than method signature
 20:Javadoc parameter order different than method signature
-28:Javadoc parameter order different than method signature
+21:Javadoc parameter order different than method signature
 29:Javadoc parameter order different than method signature
+30:Javadoc parameter order different than method signature
+43:Number of javadoc parameters different than method signature
+51:Number of javadoc parameters different than method signature


### PR DESCRIPTION
Fix IndexOutOfBoundsException occurs when number of @param tags is less then number of actual parameters.

See #1034