### PR TITLE
For #1037:Upgrade ChecksTest from qulice-checkstyle to Junit5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
                 <version>5.3.1</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-params</artifactId>
+                <version>5.3.1</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -102,6 +102,10 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
For #1037 
- Upgrade [ChecksTest](https://github.com/teamed/qulice/blob/master/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java) from Junit4 to Junit5.
- Now [ChecksTest](https://github.com/teamed/qulice/blob/master/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java) from qulice-pmd runs automatically when building by maven.
