### PR TITLE
#1009. Replace Commons-io on Cactoos in qulice-pmd.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
                 <version>3.7</version>
             </dependency>
             <dependency>
+                <groupId>org.cactoos</groupId>
+                <artifactId>cactoos</artifactId>
+                <version>0.41</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
                 <version>5.3.1</version>

--- a/qulice-checkstyle/pom.xml
+++ b/qulice-checkstyle/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>org.cactoos</groupId>
             <artifactId>cactoos</artifactId>
-            <version>0.38</version>
         </dependency>
         <dependency>
             <groupId>com.qulice</groupId>

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -50,9 +50,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 import org.apache.commons.lang3.StringUtils;
-import org.cactoos.text.ReplacedText;
+import org.cactoos.text.Replaced;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.TrimmedText;
+import org.cactoos.text.Trimmed;
 import org.xml.sax.InputSource;
 
 /**
@@ -170,8 +170,8 @@ public final class CheckstyleValidator implements ResourceValidator {
         final URL url = CheckstyleValidator.toUrl(env, name);
         final String content;
         try {
-            content = new ReplacedText(
-                new TrimmedText(
+            content = new Replaced(
+                new Trimmed(
                     new TextOf(
                         url.openStream()
                     )

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/CheckstyleValidator.java
@@ -126,7 +126,7 @@ public final class CheckstyleValidator implements ResourceValidator {
      * Load checkstyle configuration.
      * @param env The environment
      * @return The configuration just loaded
-     * @see #validate()
+     * @see #validate(Collection)
      */
     private Configuration configuration(final Environment env) {
         final File cache =
@@ -163,7 +163,7 @@ public final class CheckstyleValidator implements ResourceValidator {
      * Create header content, from file.
      * @param env The environment
      * @return The content of header
-     * @see #configuration()
+     * @see #configuration(Environment)
      */
     private String header(final Environment env) {
         final String name = env.param("license", "LICENSE.txt");

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/ProhibitNonFinalClassesCheck.java
@@ -35,7 +35,7 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
 import com.puppycrawl.tools.checkstyle.utils.ScopeUtil;
 import java.util.ArrayDeque;
 import java.util.Deque;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.UncheckedText;
 
 /**
@@ -160,7 +160,7 @@ public final class ProhibitNonFinalClassesCheck extends AbstractCheck {
             } else {
                 qualified =
                 new UncheckedText(
-                    new JoinedText(
+                    new Joined(
                         ProhibitNonFinalClassesCheck.PACKAGE_SEPARATOR,
                         pack,
                         name
@@ -170,7 +170,7 @@ public final class ProhibitNonFinalClassesCheck extends AbstractCheck {
         } else {
             qualified =
                 new UncheckedText(
-                    new JoinedText(
+                    new Joined(
                         ProhibitNonFinalClassesCheck.PACKAGE_SEPARATOR,
                         outer,
                         name

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/CheckstyleValidatorTest.java
@@ -39,7 +39,7 @@ import java.util.Collection;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.list.ListOf;
 import org.cactoos.text.FormattedText;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.cactoos.text.TextOf;
 import org.hamcrest.Description;
 import org.hamcrest.MatcherAssert;
@@ -636,7 +636,7 @@ public final class CheckstyleValidatorTest {
             file, false
         );
         final String name = "AbbreviationAsWordInNameCheck";
-        final String message = new JoinedText(
+        final String message = new Joined(
             " ",
             "Abbreviation in name '%s'",
             "must contain no more than '2' consecutive capital letters."

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/LicenseRule.java
@@ -34,7 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.FileUtils;
-import org.cactoos.text.JoinedText;
+import org.cactoos.text.Joined;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -122,7 +122,7 @@ public final class LicenseRule implements TestRule {
         FileUtils.forceDeleteOnExit(license);
         FileUtils.writeStringToFile(
             license,
-            new JoinedText(this.eol, this.lines).asString(),
+            new Joined(this.eol, this.lines).asString(),
             StandardCharsets.UTF_8
         );
         if (this.directory != null) {

--- a/qulice-maven-plugin/pom.xml
+++ b/qulice-maven-plugin/pom.xml
@@ -55,7 +55,6 @@
         <dependency>
             <groupId>org.cactoos</groupId>
             <artifactId>cactoos</artifactId>
-            <version>0.38</version>
         </dependency>
         <dependency>
             <groupId>com.qulice</groupId>

--- a/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
+++ b/qulice-maven-plugin/src/main/java/com/qulice/maven/SvnPropertiesValidator.java
@@ -36,7 +36,7 @@ import java.util.Collection;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.project.MavenProject;
 import org.cactoos.text.TextOf;
-import org.cactoos.text.TrimmedText;
+import org.cactoos.text.Trimmed;
 import org.cactoos.text.UncheckedText;
 
 /**
@@ -178,7 +178,7 @@ public final class SvnPropertiesValidator implements MavenValidator {
             final Process process = builder.start();
             process.waitFor();
             return new UncheckedText(
-                new TrimmedText(
+                new Trimmed(
                     new TextOf(
                         process.getInputStream()
                     )

--- a/qulice-pmd/pom.xml
+++ b/qulice-pmd/pom.xml
@@ -83,8 +83,8 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
+            <groupId>org.cactoos</groupId>
+            <artifactId>cactoos</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
+++ b/qulice-pmd/src/test/java/com/qulice/pmd/PmdAssert.java
@@ -32,10 +32,9 @@ package com.qulice.pmd;
 import com.qulice.spi.Environment;
 import com.qulice.spi.Violation;
 import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
-import org.apache.commons.io.IOUtils;
+import org.cactoos.text.TextOf;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 
@@ -75,18 +74,15 @@ final class PmdAssert {
     /**
      * Validated given file against PMD.
      * @throws Exception In case of error.
-     * @todo #966:5min Add Cactoos dependency to qulice-pmd and replace IOUtils
-     *  usage with Cactoos alternatives `TextOf` and `ResourceOf`
      */
     public void validate() throws Exception {
         final Environment.Mock mock = new Environment.Mock();
         final String name = String.format("src/main/java/foo/%s", this.file);
         final Environment env = mock.withFile(
             name,
-            IOUtils.toString(
-                this.getClass().getResourceAsStream(this.file),
-                StandardCharsets.UTF_8
-            )
+            new TextOf(
+                this.getClass().getResourceAsStream(this.file)
+            ).asString()
         );
         final Collection<Violation> violations = new PmdValidator(env).validate(
             Collections.singletonList(new File(env.basedir(), name))


### PR DESCRIPTION
For #1009 
- Delete commons-io dependency from pom.xml
- Add Cactoos 0.41 to qulice-pmd
- Replace `IOUtils` on `TextOf`

And

- Upgrade Cactoos to 0.41