### PR TITLE
For #1046. Now JavadocParameterOrderCheck works with Generic parameters.

### DIFF
--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Arguments.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2011-2019, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle.parameters;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Method or constructor arguments.
+ *
+ * @since 0.18.18
+ */
+public class Arguments {
+
+    /**
+     * Parameters.
+     */
+    private final Parameters parameters;
+
+    /**
+     * Secondary ctor.
+     * @param node Constructor or method defenition node.
+     */
+    public Arguments(final DetailAST node) {
+        this(
+            new Parameters(
+                node, TokenTypes.PARAMETERS, TokenTypes.PARAMETER_DEF
+            )
+        );
+    }
+
+    /**
+     * Primary ctor.
+     * @param parameters Parameters.
+     */
+    public Arguments(final Parameters parameters) {
+        this.parameters = parameters;
+    }
+
+    /**
+     * Return number of arguments.
+     * @return Number of arguments.
+     */
+    public final int count() {
+        return this.parameters.count();
+    }
+
+    /**
+     * Checks for consistency the order of arguments and their Javadoc
+     *  parameters.
+     * @param tags Javadoc parameter tags.
+     * @param consumer Consumer accepts JavadocTag which is located out of
+     *  order.
+     */
+    public final void checkOrder(
+        final List<JavadocTag> tags, final Consumer<JavadocTag> consumer
+    ) {
+        final List<DetailAST> params = this.parameters.parameters();
+        if (tags.size() < params.size()) {
+            throw new IllegalStateException(
+                // @checkstyle LineLength (1 lines)
+                "Number of Javadoc parameters does not match the number of arguments"
+            );
+        }
+        final Iterator<JavadocTag> iterator = tags.listIterator();
+        for (final DetailAST param : params) {
+            final String type =
+                param.findFirstToken(TokenTypes.IDENT).getText();
+            final JavadocTag tag = iterator.next();
+            final String arg = tag.getFirstArg();
+            if (!arg.equals(type)) {
+                consumer.accept(tag);
+            }
+        }
+    }
+}

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/Parameters.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2011-2019, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle.parameters;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Abstract parameters. Is used for Generic type parameters or
+ *  method(constructor) arguments.
+ *
+ * @since 0.18.18
+ */
+public class Parameters {
+
+    /**
+     * Class, interface, constructor or method definition node.
+     */
+    private final DetailAST node;
+
+    /**
+     * Parent TokenType (TYPE_PARAMETERS or PARAMETERS).
+     * @see com.puppycrawl.tools.checkstyle.api.TokenTypes
+     */
+    private final int parent;
+
+    /**
+     * Childs TokenType (TYPE_PARAMETER or PARAMETER_DEF).
+     * @see com.puppycrawl.tools.checkstyle.api.TokenTypes
+     */
+    private final int childs;
+
+    /**
+     * Primary ctor.
+     * @param node Class, interface, constructor or method definition node.
+     * @param parent Parent TokenType (TYPE_PARAMETERS or PARAMETERS).
+     * @param childs Childs TokenType (TYPE_PARAMETER or PARAMETER_DEF).
+     */
+    public Parameters(
+        final DetailAST node, final int parent, final int childs
+    ) {
+        this.node = node;
+        this.parent = parent;
+        this.childs = childs;
+    }
+
+    /**
+     * Return number of arguments.
+     * @return Number of parameters.
+     */
+    public final int count() {
+        final int result;
+        final DetailAST params = this.node.findFirstToken(this.parent);
+        if (params == null) {
+            result = 0;
+        } else {
+            result = params.getChildCount(this.childs);
+        }
+        return result;
+    }
+
+    /**
+     * Return parameters for this node.
+     * @return Parameters for this node.
+     */
+    public final List<DetailAST> parameters() {
+        final List<DetailAST> result;
+        final int count = this.count();
+        if (count == 0) {
+            result = Collections.emptyList();
+        } else {
+            final DetailAST params = this.node.findFirstToken(this.parent);
+            result = new ArrayList<>(count);
+            DetailAST child = params.getFirstChild();
+            while (child != null) {
+                if (child.getType() == this.childs) {
+                    result.add(child);
+                }
+                child = child.getNextSibling();
+            }
+        }
+        return result;
+    }
+}

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/TypeParameters.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2011-2019, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.qulice.checkstyle.parameters;
+
+import com.puppycrawl.tools.checkstyle.api.DetailAST;
+import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+import com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTag;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Class, interface, constructor or method generic type parameters.
+ *
+ * @since 0.18.18
+ */
+public class TypeParameters {
+
+    /**
+     * Parameters.
+     */
+    private final Parameters parameters;
+
+    /**
+     * Secondary ctor.
+     * @param node Class, interface, constructor or method defenition node.
+     */
+    public TypeParameters(final DetailAST node) {
+        this(
+            new Parameters(
+                node, TokenTypes.TYPE_PARAMETERS, TokenTypes.TYPE_PARAMETER
+            )
+        );
+    }
+
+    /**
+     * Primary ctor.
+     * @param parameters Parameters.
+     */
+    public TypeParameters(final Parameters parameters) {
+        this.parameters = parameters;
+    }
+
+    /**
+     * Return number of arguments.
+     * @return Number of arguments.
+     */
+    public final int count() {
+        return this.parameters.count();
+    }
+
+    /**
+     * Checks for consistency the order of generic type parameters and
+     * their Javadoc parameters.
+     * @param tags Javadoc parameter tags.
+     * @param consumer Consumer accepts JavadocTag which is located out of
+     *  order.
+     */
+    public final void checkOrder(
+        final List<JavadocTag> tags, final Consumer<JavadocTag> consumer
+    ) {
+        final List<DetailAST> params = this.parameters.parameters();
+        if (tags.size() < params.size()) {
+            throw new IllegalStateException(
+                // @checkstyle LineLength (1 lines)
+                "Number of Javadoc parameters does not match the number of type parameters"
+            );
+        }
+        final Iterator<JavadocTag> iterator =
+            tags.listIterator(tags.size() - params.size());
+        for (final DetailAST param : params) {
+            final String type =
+                param.findFirstToken(TokenTypes.IDENT).getText();
+            final JavadocTag tag = iterator.next();
+            final String arg = tag.getFirstArg();
+            if (!arg.equals(String.format("<%s>", type))) {
+                consumer.accept(tag);
+            }
+        }
+    }
+}

--- a/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/package-info.java
+++ b/qulice-checkstyle/src/main/java/com/qulice/checkstyle/parameters/package-info.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2019, Qulice.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the Qulice.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Argument and generic type parameters.
+ *
+ * @since 0.18.18
+ */
+package com.qulice.checkstyle.parameters;

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -45,6 +45,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -59,7 +61,34 @@ import org.xml.sax.InputSource;
 public final class ChecksTest {
 
     /**
+     * Disabled test case.
+     */
+    private static final String DISABLED = "ChecksTest/JavadocParameterOrderCheck";
+
+    /**
+     * Disabled JavadocParameterOrderCheck.
      * Test checkstyle for true positive.
+     * @throws Exception If something goes wrong
+     */
+    @Disabled
+    @Test
+    public void testJavadocParameterOrderCheckTruePositive() throws Exception {
+        this.testCheckstyleTruePositive(DISABLED);
+    }
+
+    /**
+     * Disabled JavadocParameterOrderCheck.
+     * Test checkstyle for true positive.
+     * @throws Exception If something goes wrong
+     */
+    @Disabled
+    @Test
+    public void testJavadocParameterOrderCheckTrueNegative() throws Exception {
+        this.testCheckstyleTrueNegative(DISABLED);
+    }
+
+    /**
+     * Test checkstyle for true negative.
      * @param dir Directory where test scripts are located.
      * @throws Exception If something goes wrong
      */
@@ -180,7 +209,6 @@ public final class ChecksTest {
             "NonStaticMethodCheck",
             "ConstantUsageCheck",
             "JavadocEmptyLineCheck",
-            "JavadocParameterOrderCheck",
             "JavadocTagsCheck",
             "ProhibitNonFinalClassesCheck"
         ).map(s -> String.format("ChecksTest/%s", s));

--- a/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
+++ b/qulice-checkstyle/src/test/java/com/qulice/checkstyle/ChecksTest.java
@@ -45,8 +45,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
@@ -59,33 +57,6 @@ import org.xml.sax.InputSource;
  * @since 0.3
  */
 public final class ChecksTest {
-
-    /**
-     * Disabled test case.
-     */
-    private static final String DISABLED = "ChecksTest/JavadocParameterOrderCheck";
-
-    /**
-     * Disabled JavadocParameterOrderCheck.
-     * Test checkstyle for true positive.
-     * @throws Exception If something goes wrong
-     */
-    @Disabled
-    @Test
-    public void testJavadocParameterOrderCheckTruePositive() throws Exception {
-        this.testCheckstyleTruePositive(DISABLED);
-    }
-
-    /**
-     * Disabled JavadocParameterOrderCheck.
-     * Test checkstyle for true positive.
-     * @throws Exception If something goes wrong
-     */
-    @Disabled
-    @Test
-    public void testJavadocParameterOrderCheckTrueNegative() throws Exception {
-        this.testCheckstyleTrueNegative(DISABLED);
-    }
 
     /**
      * Test checkstyle for true negative.
@@ -202,6 +173,7 @@ public final class ChecksTest {
             "BracketsStructureCheck",
             "CurlyBracketsStructureCheck",
             "JavadocLocationCheck",
+            "JavadocParameterOrderCheck",
             "MethodBodyCommentsCheck",
             "RequireThisCheck",
             "ProtectedMethodInFinalClassCheck",

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Invalid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Invalid.java
@@ -6,8 +6,12 @@ package com.qulice.checkstyle;
 /**
  * This is not a real Java class. It won't be compiled ever. It is used
  * only as a text resource in integration.ChecksIT.
+ *
+ * Wrong order of parameters.
+ * @param <V> - value.
+ * @param <K> - key.
  */
-public final class Invalid {
+public final class Invalid<K, V> {
 
     /**
      * A field.
@@ -50,5 +54,32 @@ public final class Invalid {
      */
     public String method3(final String hparam) {
         return hparam;
+    }
+
+    /**
+     * Javadoc without generic parameter at the end.
+     * @param list
+     * @return Element.
+     */
+    public <T> T first(final List<T> list) {
+        return list.get(0);
+    }
+
+    /**
+     * Javadoc with parameters in different order than the method signature.
+     * @param <T> - type.
+     * @param list - list.
+     * @param index - index.
+     * @return Element.
+     */
+    public <T> T get(final List<T> list, final int index) {
+        return list.get(index);
+    }
+
+    /**
+     * Javadoc without generic parameters.
+     */
+    public final static class InnerEntry<K, V> {
+
     }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Valid.java
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/Valid.java
@@ -32,4 +32,24 @@ public final class Valid {
     public String method(final String bparam, final String aparam) {
         return bparam + aparam;
     }
+
+    /**
+     * Correct order of parameters.
+     * @param list List.
+     * @param index Index.
+     * @param <T> Type.
+     * @return Element.
+     */
+    public <T> T get(final List<T> list, final int index) {
+        return list.get(index);
+    }
+
+    /**
+     * Correct order of parameters.
+     * @param <K> Key.
+     * @param <V> Value.
+     */
+    public final static class Entry<K, V> {
+
+    }
 }

--- a/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/violations.txt
+++ b/qulice-checkstyle/src/test/resources/com/qulice/checkstyle/ChecksTest/JavadocParameterOrderCheck/violations.txt
@@ -1,6 +1,13 @@
-20:Javadoc parameter order different than method signature
-21:Javadoc parameter order different than method signature
-29:Javadoc parameter order different than method signature
-30:Javadoc parameter order different than method signature
-43:Number of javadoc parameters different than method signature
-51:Number of javadoc parameters different than method signature
+11:Javadoc parameter order different than method signature
+12:Javadoc parameter order different than method signature
+24:Javadoc parameter order different than method signature
+25:Javadoc parameter order different than method signature
+33:Javadoc parameter order different than method signature
+34:Javadoc parameter order different than method signature
+47:Number of javadoc parameters different than method signature
+55:Number of javadoc parameters different than method signature
+64:Number of javadoc parameters different than method signature
+70:Javadoc parameter order different than method signature
+71:Javadoc parameter order different than method signature
+72:Javadoc parameter order different than method signature
+82:Number of javadoc parameters different than method signature


### PR DESCRIPTION
For #1046 
- Add test cases
- Implemented functionality for working with Generic parameters