### PR TITLE
Fix the logo on qulice.com

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -37,7 +37,7 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
   <googleAnalyticsAccountId>UA-1963507-25</googleAnalyticsAccountId>
   <bannerLeft>
     <name>Qulice</name>
-    <src>http://img.qulice.com/logo.svg</src>
+    <src>https://camo.githubusercontent.com/21b0e8be23deb3c2743027b82fda3af26c04ebfbb43faf5fc73c01b66607f8bf/687474703a2f2f696d672e71756c6963652e636f6d2f6c6f676f2e737667</src>
     <href>http://www.qulice.com/</href>
     <title>home page of Qulice.com</title>
     <width>214</width>


### PR DESCRIPTION
Replace broken src link to [working one](https://camo.githubusercontent.com/21b0e8be23deb3c2743027b82fda3af26c04ebfbb43faf5fc73c01b66607f8bf/687474703a2f2f696d672e71756c6963652e636f6d2f6c6f676f2e737667) from readme.md